### PR TITLE
Four new phpdocs validations (valid normal and inline tags)

### DIFF
--- a/file.php
+++ b/file.php
@@ -772,6 +772,27 @@ class local_moodlecheck_file {
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class local_moodlecheck_phpdocs {
+    /** @var array static property storing the list of valid,
+     * well known, phpdocs tags, always accepted.
+     * @link http://manual.phpdoc.org/HTMLSmartyConverter/HandS/ */
+    public static $validtags = array(
+        'abstract', 'access', 'author', 'category', 'copyright',
+        'deprecated', 'example', 'final', 'fileresource', 'global',
+        'ignore', 'internal', 'license', 'link', 'method',
+        'name', 'package', 'param', 'property', 'return',
+        'see', 'since', 'static', 'staticvar', 'subpackage',
+        'todo', 'tutorial', 'uses', 'var', 'version');
+    /** @var array static property storing the list of recommended
+     * phpdoc tags to use within Moodle phpdocs.
+     * @link http://docs.moodle.org/dev/Coding_style */
+    public static $recommendedtags = array(
+        'author', 'category', 'copyright', 'deprecated', 'license',
+        'link', 'package', 'param', 'return', 'see',
+        'since', 'subpackage', 'todo', 'uses', 'var');
+    /** @var array static property storing the list of phpdoc tags
+     * allowed to be used inline within Moodle phpdocs. */
+     public static $inlinetags = array(
+         'link');
     /** @var array stores the original token for this phpdocs */
     protected $originaltoken = null;
     /** @var int stores id the original token for this phpdocs */
@@ -966,5 +987,38 @@ class local_moodlecheck_phpdocs {
                 return $line0;
             }
         }
+    }
+
+    /**
+     * Returns all the inline tags found in the phpdoc
+     *
+     * This method returns all the phpdocs tags found inline,
+     * embed into the phpdocs contents. Only valid tags are
+     * considered See {@link self::$validtags}.
+     *
+     * @param bool $withcurly if true, only tags properly enclosed
+     *        with curly brackets are returned. Else all the inline tags are returned.
+     *
+     * @return array inline tags found in the phpdoc, without
+     * any cleaning and including curly braces if present
+     */
+    public function get_inline_tags($withcurly = true) {
+        $inlinetags = array();
+        // Trim the non-inline phpdocs tags
+        $text = preg_replace('|^\s*@?|m', '', $this->trimmedtext);
+        if ($withcurly) {
+            $regex = '#{@([a-z]*).*?}#';
+        } else {
+            $regex = '#@([a-z]*).*?#';
+        }
+        if (preg_match_all($regex, $text, $matches)) {
+            // Filter out invalid ones, can be ignored
+            foreach ($matches[1] as $tag) {
+                if (in_array($tag, self::$validtags)) {
+                    $inlinetags[] = $tag;
+                }
+            }
+        }
+        return $inlinetags;
     }
 }

--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -55,6 +55,19 @@ $string['error_noinlinephpdocs'] = 'Found comment starting with three or more sl
 $string['error_phpdocsfistline'] = 'No one-line description found in phpdocs for <b>{$a->object}</b>';
 $string['rule_phpdocsfistline'] = 'File-level phpdocs block and class phpdocs should have one-line short description';
 
+$string['error_phpdocsinvalidtag'] = 'Invalid phpdocs tag <b>{$a->tag}</b> used';
+$string['rule_phpdocsinvalidtag'] = 'Used phpdocs tags are valid';
+
+$string['error_phpdocsnotrecommendedtag'] = 'Not recommended phpdocs tag <b>{$a->tag}</b> used';
+$string['rule_phpdocsnotrecommendedtag'] = 'Used phpdocs tags are recommended';
+
+$string['error_phpdocsinvalidinlinetag'] = 'Invalid inline phpdocs tag <b>{$a->tag}</b> found';
+$string['rule_phpdocsinvalidinlinetag'] = 'Inline phpdocs tags are valid';
+
+$string['error_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tag not enclosed with curly brackets <b>{$a->tag}</b> found';
+$string['rule_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tags are enclosed with curly brackets';
+
+
 $string['error_functiondescription'] = 'There is no description in phpdocs for function <b>{$a->object}</b>';
 $string['rule_functiondescription'] = 'Functions have descriptions in phpdocs';
 $string['error_functionarguments'] = 'Phpdocs for function <b>{$a->function}</b> has incomplete parameters list';


### PR DESCRIPTION
This patch introduces the official list of valid phpdocs tags,
the list of recommended tags to be used by Moodle and the list
of valid tags to be used inline.

Based on that information, 4 new rules are added:
- Error if invalid phpdoc tag is found
- Warning if not recommended moodle tag is found
- Error if not inline-valid tag is found
- Errot if inline-valid tag is not enclosed by curly brackets
