### PR TITLE
Improve a bit line numbers reporting for wrong tags

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -190,7 +190,7 @@ function local_moodlecheck_phpdocsinvalidtag(local_moodlecheck_file $file) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
             if (!in_array($tag, local_moodlecheck_phpdocs::$validtags)) {
                 $errors[] = array(
-                    'line' => $phpdocs->get_line_number($file),
+                    'line' => $phpdocs->get_line_number($file, '@' . $tag),
                     'tag' => '@' . $tag);
             }
         }
@@ -212,7 +212,7 @@ function local_moodlecheck_phpdocsnotrecommendedtag(local_moodlecheck_file $file
             if (in_array($tag, local_moodlecheck_phpdocs::$validtags) and
                     !in_array($tag, local_moodlecheck_phpdocs::$recommendedtags)) {
                 $errors[] = array(
-                    'line' => $phpdocs->get_line_number($file),
+                    'line' => $phpdocs->get_line_number($file, '@' . $tag),
                     'tag' => '@' . $tag);
             }
         }
@@ -233,7 +233,7 @@ function local_moodlecheck_phpdocsinvalidinlinetag(local_moodlecheck_file $file)
             foreach ($inlinetags as $inlinetag) {
                 if (!in_array($inlinetag, local_moodlecheck_phpdocs::$inlinetags)) {
                     $errors[] = array(
-                        'line' => $phpdocs->get_line_number($file),
+                        'line' => $phpdocs->get_line_number($file, '@' . $inlinetag),
                         'tag' => '@' . $inlinetag);
                 }
             }
@@ -257,7 +257,7 @@ function local_moodlecheck_phpdocsuncurlyinlinetag(local_moodlecheck_file $file)
             foreach ($diff as $inlinetag) {
                 if (in_array($inlinetag, local_moodlecheck_phpdocs::$inlinetags)) {
                     $errors[] = array(
-                        'line' => $phpdocs->get_line_number($file),
+                        'line' => $phpdocs->get_line_number($file, '@' . $inlinetag),
                         'tag' => '@' . $inlinetag);
                 }
             }


### PR DESCRIPTION
Just discovered the 2nd param to the get_line_number() method, in order to find more accurate lines... and I've applied it to the 4 checks introduced last week.

I've one bigger patch ongoing about to encapsulate the found tags into one phpdocs_tag object, each one having as attribute the line number, the contents... but perhaps it would cause the whole thing to go noticeably slower... although more accurate (one point that is really critical for the patch-checker, coz it only reports lines modified by the patch).

Anyway, not ready yet... just to let you know.
