### PR TITLE
Remote and componentsfromfile

### DIFF
--- a/cli/moodlecheck.php
+++ b/cli/moodlecheck.php
@@ -30,8 +30,8 @@ require_once($CFG->dirroot. '/local/moodlecheck/locallib.php');
 
 // now get cli options
 list($options, $unrecognized) = cli_get_params(
-        array('help'=>false, 'path'=>'', 'format'=>'xml', 'exclude'=>'', 'rules'=>'all'),
-        array('h'=>'help', 'p'=>'path', 'f'=>'format', 'e'=>'exclude', 'r'=>'rules')
+        array('help'=>false, 'path'=>'', 'format'=>'xml', 'exclude'=>'', 'rules'=>'all', 'componentsfile'=>''),
+        array('h'=>'help', 'p'=>'path', 'f'=>'format', 'e'=>'exclude', 'r'=>'rules', 'c'=>'componentsfile')
     );
 
 $rules = preg_split('/\s*[\n,;]\s*/', trim($options['rules']), null, PREG_SPLIT_NO_EMPTY);
@@ -55,6 +55,7 @@ Options:
                       automatically excluded
 -r, --rules           List rules to check against. Default 'all'
 -f, --format          Output format: html, xml, text. Default 'xml'
+-c, --componentsfile  Path to one file contaning the list of valid components in format: type, name, fullpath
 
 Example:
 \$sudo -u www-data /usr/bin/php local/moodlecheck/cli/moodlecheck.php -p=local/moodlecheck
@@ -88,5 +89,6 @@ if (count($rules) && !in_array('all', $rules)) {
 }
 foreach ($paths as $filename) {
     $path = new local_moodlecheck_path($filename, $exclude);
+    local_moodlecheck_path::get_components($options['componentsfile']);
     echo $output->display_path($path, $options['format']);
 }

--- a/file.php
+++ b/file.php
@@ -543,7 +543,7 @@ class local_moodlecheck_file {
             } else {
                 // no idea what it is!
                 // TODO: change to debugging
-                echo "************ Unknown preceeding token id = {$tokens[$i][0]}, text = '{$tokens[$i][1]}' **************<br>";
+                //echo "************ Unknown preceeding token id = {$tokens[$i][0]}, text = '{$tokens[$i][1]}' **************<br>";
                 return false;
             }
         }
@@ -654,7 +654,7 @@ class local_moodlecheck_file {
                         $found = false;
                     } else {
                         // TODO: change to debugging
-                        echo "************ Unknown token following the first phpdocs in {$this->filepath}: id = {$nexttoken[0]}, text = '{$nexttoken[1]}' **************<br>";
+                        //echo "************ Unknown token following the first phpdocs in {$this->filepath}: id = {$nexttoken[0]}, text = '{$nexttoken[1]}' **************<br>";
                     }
                 }
             }

--- a/locallib.php
+++ b/locallib.php
@@ -253,6 +253,34 @@ class local_moodlecheck_path {
     public function is_rootpath() {
         return $this->rootpath;
     }
+
+    public static function get_components($componentsfile = null) {
+        static $components = array();
+        if (!empty($components)) {
+            return $components;
+        }
+        if (empty($componentsfile)) {
+            return array();
+        }
+        if (file_exists($componentsfile) and is_readable($componentsfile)) {
+            $fh = fopen($componentsfile, 'r');
+            while (($line = fgets($fh, 4096)) !== false) {
+                $split = explode(',', $line);
+                if (count($split) != 3) {
+                    // Wrong count of elements in the line
+                    continue;
+                }
+                if (trim($split[0]) != 'plugin' and trim($split[0]) != 'subsystem') {
+                    // Wrong type
+                    continue;
+                }
+                // Let's assume it's a correct line
+                $components[trim($split[0])][trim($split[1])] = trim($split[2]);
+            }
+            fclose($fh);
+        }
+        return $components;
+    }
 }
 
 /**


### PR DESCRIPTION
This patch adds 2 functionalities to the checker (CLI):
- Ability to inspect remote paths out from own codebase: If one existing full path is provided, it's checked.
- Ability to rely in one static file containing all the plugins and subsystems available, instead of extracting them from current codebase.

This 2 functionalities shouldn't affect normal (wen/cli) self-execution at all, but are required by the CI server in order to be able to check different branches (with different plugins/subsystems) in any readable location (the CI server own git clones).

For your consideration, TIA and ciao :-)
