### PR TITLE
Change all the (deprecated since 5.3) uses of split() by preg_split() or explode() alternatives.

### DIFF
--- a/file.php
+++ b/file.php
@@ -759,7 +759,7 @@ class local_moodlecheck_file {
         } else if ($tid == 0) {
             return 1;
         } else {
-            return $this->get_line_number($tid-1) + count(split("\n", $tokens[$tid-1][1])) - 1;
+            return $this->get_line_number($tid-1) + count(preg_split('/\n/', $tokens[$tid-1][1])) - 1;
         }
     }
 }
@@ -979,9 +979,9 @@ class local_moodlecheck_phpdocs {
         if ($substring === null) {
             return $line0;
         } else {
-            $chunks = split($substring, $this->originaltoken[1]);
+            $chunks = preg_split('!' . $substring . '!', $this->originaltoken[1]);
             if (count($chunks) > 1) {
-                $lines = split("\n", $chunks[0]);
+                $lines = preg_split('/\n/', $chunks[0]);
                 return $line0 + count($lines) - 1;
             } else {
                 return $line0;

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -191,7 +191,7 @@ function &local_moodlecheck_get_categories() {
         $lastsavedvalue = get_user_preferences('local_moodlecheck_categoriesvalue');
         if ($lastsavedtime > time() - 24*60*60) {
             // update only once per day
-            $allcategories = split(',', $lastsavedvalue);
+            $allcategories = explode(',', $lastsavedvalue);
         } else {
             $allcategories = array();
             $filecontent = file_get_contents("http://docs.moodle.org/dev/Core_APIs");


### PR DESCRIPTION
As far as new error reporting levels in 2.3 and upwards is going to show deprecated uses, change split() by non-deprecated alternatives.
