### PR TITLE
Ignoring closures

### DIFF
--- a/file.php
+++ b/file.php
@@ -216,6 +216,11 @@ class local_moodlecheck_file {
                     $function = new stdClass();
                     $function->tid = $tid;
                     $function->fullname = $function->name = $this->next_nonspace_token($tid, false, array('&'));
+
+                    // Skip anonymous functions.
+                    if ($function->name == '(') {
+                        continue;
+                    }
                     $function->phpdocs = $this->find_preceeding_phpdoc($tid);
                     $function->class = $this->is_inside_class($tid);
                     if ($function->class !== false) {


### PR DESCRIPTION
They are not part of any API and can not be called as other functions.

Using PHP tokenizer I doubt there is another way to detect when are we dealing with a closure
