### PR TITLE
MDLSITE-2216 Prevent debugging in deprecated call

### DIFF
--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -128,7 +128,7 @@ function local_moodlecheck_package_names(local_moodlecheck_file $file) {
         if (isset($components['subsystem'])) {
             $allsubsystems = $components['subsystem'];
         } else {
-            $allsubsystems = get_core_subsystems();
+            $allsubsystems = get_core_subsystems(true);
         }
         // Prepare the list of core packages
         foreach ($allsubsystems as $subsystem => $dir) {


### PR DESCRIPTION
get_core_subsystems() now deprecated, does no support short paths
anymore. This commit just change the call to ask for full paths
always to avoid a debugging() message. Note we don't change to the
new core_component::get_subsystems() because that would lead the
moodlecheck to only work against 2.6 and upwards. So we continue
using the deprecated call.
