### PR TITLE
Added support for PHPDoc array params.

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -325,10 +325,13 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
             $match = (count($documentedarguments) == count($function->arguments));
             for ($i=0; $match && $i<count($documentedarguments); $i++) {
                 if (count($documentedarguments[$i]) < 2) {
-                    // must be at least type and parameter name
+                    // Must be at least type and parameter name.
                     $match = false;
                 } else if (strlen($function->arguments[$i][0]) && $function->arguments[$i][0] != $documentedarguments[$i][0]) {
-                    $match = false;
+                    // It could be a type hinted array.
+                    if ($function->arguments[$i][0] !== 'array' || substr($documentedarguments[$i][0], -2) !== '[]') {
+                        $match = false;
+                    }
                 } else if ($documentedarguments[$i][0] == 'type') {
                     $match = false;
                 } else if ($function->arguments[$i][1] != $documentedarguments[$i][1]) {


### PR DESCRIPTION
The following is now supported by moodlecheck:

```
/**
 * @param stdClass[] $objectarray An array of stdClass objects.
 */
function some_func(array $objectarray) {}
```

An example of this is shown at
    http://www.phpdoc.org/docs/latest/for-users/phpdoc/tags/param.html
