### PR TITLE
Fixed bug when parsing namespaced typehint args

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -325,14 +325,27 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
             $match = (count($documentedarguments) == count($function->arguments));
             for ($i=0; $match && $i<count($documentedarguments); $i++) {
                 if (count($documentedarguments[$i]) < 2) {
-                    // must be at least type and parameter name
+                    // Must be at least type and parameter name.
                     $match = false;
-                } else if (strlen($function->arguments[$i][0]) && $function->arguments[$i][0] != $documentedarguments[$i][0]) {
-                    $match = false;
-                } else if ($documentedarguments[$i][0] == 'type') {
-                    $match = false;
-                } else if ($function->arguments[$i][1] != $documentedarguments[$i][1]) {
-                    $match = false;
+                } else {
+                    $expectedtype = $function->arguments[$i][0];
+                    $expectedparam = $function->arguments[$i][1];
+                    $documentedtype = $documentedarguments[$i][0];
+                    $documentedparam = $documentedarguments[$i][1];
+
+                    if (strpos($documentedtype, '\\') !== false) {
+                        // Namespaced typehint, potentially sub-namespaced.
+                        // We need to strip namespacing as this area just isn't that smart.
+                        $documentedtype = substr($documentedtype, strrpos($documentedtype, '\\') + 1);
+                    }
+
+                    if (strlen($expectedtype) && $expectedtype !== $documentedtype) {
+                        $match = false;
+                    } else if ($documentedtype === 'type') {
+                        $match = false;
+                    } else if ($expectedparam !== $documentedparam) {
+                        $match = false;
+                    }
                 }
             }
             $documentedreturns = $function->phpdocs->get_params('return');


### PR DESCRIPTION
There is a bug with the moodlecheck functionargs check.

It doesn't nicely parse typehints that are namespaced.
For example prior to this patch the following would trigger the check to fail.

```
<?php
// This file is part of Moodle - http://moodle.org/
//
// Moodle is free software: you can redistribute it and/or modify
// it under the terms of the GNU General Public License as published by
// the Free Software Foundation, either version 3 of the License, or
// (at your option) any later version.
//
// Moodle is distributed in the hope that it will be useful,
// but WITHOUT ANY WARRANTY; without even the implied warranty of
// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
// GNU General Public License for more details.
//
// You should have received a copy of the GNU General Public License
// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.

/**
 * Test script
 *
 * @package    core
 * @copyright  2013 Sam Hemelryk
 * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 */

namespace one\two {
    /**
     * Class foo
     * @copyright  2013 Sam Hemelryk
     * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
     */
    class foo {}
}

namespace three {
    /**
     * Class bar
     * @copyright  2013 Sam Hemelryk
     * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
     */
    class bar {
        /**
         * This is three.
         * @param \one\two\foo $foo
         */
        public function __construct(\one\two\foo $foo) {}
    }
}
```
