### PR TITLE
Adding PHPUnit tags to valid and allowed whitelists.

### DIFF
--- a/file.php
+++ b/file.php
@@ -827,7 +827,28 @@ class local_moodlecheck_phpdocs {
         'tutorial',
         'uses',
         'var',
-        'version'
+        'version',
+        // PHPUnit tags.
+        'backupGlobals',
+        'backupStaticAttributes',
+        'codeCoverageIgnore',
+        'covers',
+        'coversDefaultClass',
+        'coversNothing',
+        'dataProvider',
+        'depends',
+        'expectedException',
+        'expectedExceptionCode',
+        'expectedExceptionMessage',
+        'group',
+        'large',
+        'medium',
+        'preserveGlobalState',
+        'requires',
+        'runTestsInSeparateProcesses',
+        'runInSeparateProcess',
+        'small',
+        'test'
     );
     /** @var array static property storing the list of recommended
      * phpdoc tags to use within Moodle phpdocs.
@@ -856,7 +877,15 @@ class local_moodlecheck_phpdocs {
         'throws',
         'todo',
         'uses',
-        'var'
+        'var',
+        // PHPUnit tags.
+        'dataProvider',
+        'depends',
+        'expectedException',
+        'expectedExceptionCode',
+        'expectedExceptionMessage',
+        'group',
+        'large'
     );
     /** @var array static property storing the list of phpdoc tags
      * allowed to be used under certain directories. keys are tags, values are
@@ -865,7 +894,27 @@ class local_moodlecheck_phpdocs {
     public static $pathrestrictedtags = array(
         'Given' => array('#.*/tests/behat/.*#'),
         'Then' => array('#.*/tests/behat/.*#'),
-        'When' => array('#.*/tests/behat/.*#')
+        'When' => array('#.*/tests/behat/.*#'),
+        'backupGlobals' => array('#.*/tests/.*#'),
+        'backupStaticAttributes' => array('#.*/tests/.*#'),
+        'codeCoverageIgnore' => array('#.*/tests/.*#'),
+        'covers' => array('#.*/tests/.*#'),
+        'coversDefaultClass' => array('#.*/tests/.*#'),
+        'coversNothing' => array('#.*/tests/.*#'),
+        'dataProvider' => array('#.*/tests/.*#'),
+        'depends' => array('#.*/tests/.*#'),
+        'expectedException' => array('#.*/tests/.*#'),
+        'expectedExceptionCode' => array('#.*/tests/.*#'),
+        'expectedExceptionMessage' => array('#.*/tests/.*#'),
+        'group' => array('#.*/tests/.*#'),
+        'large' => array('#.*/tests/.*#'),
+        'medium' => array('#.*/tests/.*#'),
+        'preserveGlobalState' => array('#.*/tests/.*#'),
+        'requires' => array('#.*/tests/.*#'),
+        'runTestsInSeparateProcesses' => array('#.*/tests/.*#'),
+        'runInSeparateProcess' => array('#.*/tests/.*#'),
+        'small' => array('#.*/tests/.*#'),
+        'test' => array('#.*/tests/.*#')
     );
     /** @var array static property storing the list of phpdoc tags
      * allowed to be used inline within Moodle phpdocs. */


### PR DESCRIPTION
See http://phpunit.de/manual/3.7/en/appendixes.annotations.html#appendixes.annotations.group

I am trying to get my PHPUnit tests to pass the Moodle coding style checker, but it doesn't like some of the tags I use. The main PHPUnit tags I use are:
- dataProvider // Useful for writing tests with a large set of data that can be programmatically generated.
- group // If is even recommended in http://docs.moodle.org/dev/PHPUnit#Using_the_.40group_annotation
- depends // Useful to ignore certain unit tests if a certain other one fails.
- expectedException, expectedExceptionCode, expectedExceptionMessage // Useful for check that exceptions on error conditions occur rather than doing a try/catch (shorter code).

I haven't used "long" yet, but in the Moodle PHPUnit docs there is a section about long tests. Maybe if we can tag certain tests as being long, we can exclude them during the group filter: http://docs.moodle.org/dev/Writing_PHPUnit_tests#Long_tests

Also, I noticed that a lot of Moodle core unit tests have "@category phpunit", but that is an invalid category according to this checker. Should that be changed? Or core code changed to use "test" as a valid category?
