### PR TITLE
MDLSITE-3282 don't complain about plain test methods

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -105,10 +105,16 @@ function local_moodlecheck_classesdocumented(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
+
+    $isphpunitfile = preg_match('#/tests/[^/]+_test\.php$#', $file->get_filepath());
     $errors = array();
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs === false) {
-            $errors[] = array('function' => $function->fullname, 'line' => $file->get_line_number($function->boundaries[0]));
+            // Exception is made for plain phpunit test methods MDLSITE-3282.
+            $istestmethod = (strpos($function->name, 'test_') === 0);
+            if (!($isphpunitfile && $istestmethod)) {
+                $errors[] = array('function' => $function->fullname, 'line' => $file->get_line_number($function->boundaries[0]));
+            }
         }
     }
     return $errors;


### PR DESCRIPTION
It has become sort of a de-facto standard to have no phpdocs on test
methods in Moodle phpunit tests. This makes a lot of sense because:
- The test name should be the descriptive part - as it also is the most
  commonly shared part of any failure
- Extensive phpdoc blocks that they easily get outdated as someone adds
  another few assertions to address whats going
