### PR TITLE
normalize file paths to make checks for package system independent

### DIFF
--- a/file.php
+++ b/file.php
@@ -51,7 +51,7 @@ class local_moodlecheck_file {
      * @param string $filepath
      */
     public function __construct($filepath) {
-        $this->filepath = $filepath;
+        $this->filepath = str_replace(DIRECTORY_SEPARATOR, "/", $filepath);
     }
 
     /**
@@ -76,6 +76,8 @@ class local_moodlecheck_file {
      * @return bool
      */
     public function is_in_dir($dirpath) {
+        // Normalize dir path to also work with Windows style directory separators...
+        $dirpath = str_replace(DIRECTORY_SEPARATOR, "/", $dirpath);
         if (substr($dirpath, -1) != '/') {
             $dirpath .= '/';
         }


### PR DESCRIPTION
To be able use local_moodlecheck on Windows development environments too, it is cucial, that filepaths are normalized, so it won't echo warnings or errors due to mismatch of '\' and '/' as directory separators.
