### PR TITLE
MDL-60786 Stop requiring @copyright and @license for individual classes

### DIFF
--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -91,12 +91,8 @@ $string['error_packagevalid'] = 'Package <b>{$a->package}</b> is not valid';
 $string['rule_categoryvalid'] = 'Category tag is valid';
 $string['error_categoryvalid'] = 'Category <b>{$a->category}</b> is not valid';
 
-$string['rule_classeshavecopyright'] = 'All classes have @copyright tag';
-$string['error_classeshavecopyright'] = 'Class <b>{$a->object}</b> does not have @copyright tag';
 $string['rule_filehascopyright'] = 'Files have @copyright tag';
 $string['error_filehascopyright'] = 'File-level phpdocs block does not have @copyright tag';
 
-$string['rule_classeshavelicense'] = 'All classes have @license tag';
-$string['error_classeshavelicense'] = 'Class <b>{$a->object}</b> does not have @license tag';
 $string['rule_filehaslicense'] = 'Files have @license tag';
 $string['error_filehaslicense'] = 'File-level phpdocs block does not have @license tag';

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -38,9 +38,7 @@ local_moodlecheck_registry::add_rule('functionarguments')->set_callback('local_m
 local_moodlecheck_registry::add_rule('variableshasvar')->set_callback('local_moodlecheck_variableshasvar');
 local_moodlecheck_registry::add_rule('definedoccorrect')->set_callback('local_moodlecheck_definedoccorrect');
 local_moodlecheck_registry::add_rule('filehascopyright')->set_callback('local_moodlecheck_filehascopyright');
-local_moodlecheck_registry::add_rule('classeshavecopyright')->set_callback('local_moodlecheck_classeshavecopyright');
 local_moodlecheck_registry::add_rule('filehaslicense')->set_callback('local_moodlecheck_filehaslicense');
-local_moodlecheck_registry::add_rule('classeshavelicense')->set_callback('local_moodlecheck_classeshavelicense');
 local_moodlecheck_registry::add_rule('phpdocsinvalidtag')->set_callback('local_moodlecheck_phpdocsinvalidtag');
 local_moodlecheck_registry::add_rule('phpdocsnotrecommendedtag')->set_callback('local_moodlecheck_phpdocsnotrecommendedtag')->set_severity('warning');
 local_moodlecheck_registry::add_rule('phpdocsinvalidpathtag')->set_callback('local_moodlecheck_phpdocsinvalidpathtag')->set_severity('warning');
@@ -460,25 +458,6 @@ function local_moodlecheck_filehascopyright(local_moodlecheck_file $file) {
 }
 
 /**
- * Makes sure that all classes have copyright tag
- *
- * @param local_moodlecheck_file $file
- * @return array of found errors
- */
-function local_moodlecheck_classeshavecopyright(local_moodlecheck_file $file) {
-    $errors = array();
-    foreach ($file->get_classes() as $class) {
-        if ($class->phpdocs && !count($class->phpdocs->get_tags('copyright', true))) {
-            $errors[] = array(
-                'line' => $class->phpdocs->get_line_number($file, '@copyright'),
-                'object' => $class->name
-            );
-        }
-    }
-    return $errors;
-}
-
-/**
  * Makes sure that files have license tag
  *
  * @param local_moodlecheck_file $file
@@ -490,23 +469,4 @@ function local_moodlecheck_filehaslicense(local_moodlecheck_file $file) {
         return array(array('line' => $phpdocs->get_line_number($file, '@license')));
     }
     return array();
-}
-
-/**
- * Makes sure that all classes have license tag
- *
- * @param local_moodlecheck_file $file
- * @return array of found errors
- */
-function local_moodlecheck_classeshavelicense(local_moodlecheck_file $file) {
-    $errors = array();
-    foreach ($file->get_classes() as $class) {
-        if ($class->phpdocs && !count($class->phpdocs->get_tags('license', true))) {
-            $errors[] = array(
-                'line' => $class->phpdocs->get_line_number($file, '@license'),
-                'object' => $class->name
-            );
-        }
-    }
-    return $errors;
 }

--- a/tests/fixtures/classtags.php
+++ b/tests/fixtures/classtags.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture file providing a class.
+ *
+ * @package     local_moodlecheck
+ * @copyright   2018 David Mudrák <david@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy class without any tags.
+ */
+class dummy_class_without_tags {
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -76,4 +76,19 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertNotContains('line="42"', $result);
         $this->assertNotContains('classesdocumented', $result);
     }
+
+    /**
+     * Assert that classes do not need to have any particular phpdocs tags.
+     */
+    public function test_classtags() {
+        global $PAGE;
+
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/classtags.php ', null);
+
+        $result = $output->display_path($path, 'xml');
+
+        $this->assertNotContains('classeshavecopyright', $result);
+        $this->assertNotContains('classeshavelicense', $result);
+    }
 }


### PR DESCRIPTION
This made sense in the past where we typically had many classes in one
library file and it was useful to keep track of who holds copyright and
credit for each of the added class.

But today, with autoloading being the common and recommended practise,
we only have one class per file. So the information about the copyright
and license is typically duplicated - once in the file's phpdoc block
and then the same info in the class' block.