### PR TITLE
Show success/error summary after report.

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,9 +63,19 @@ if ($form->is_submitted() && $form->is_validated()) {
     } else {
         local_moodlecheck_registry::enable_all_rules();
     }
+
+    // Store result for later output.
+    $result = [];
+
     foreach ($paths as $filename) {
         $path = new local_moodlecheck_path($filename, $ignorepaths);
-        echo $output->display_path($path);
+        $result[] = $output->display_path($path);
+    }
+
+    echo $output->display_summary();
+
+    foreach ($result as $line) {
+        echo $line;
     }
 }
 

--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -31,6 +31,8 @@ $string['checkallrules'] = 'Check over all rules';
 $string['checkselectedrules'] = 'Check over selected rules';
 $string['error_default'] = 'Error: {$a}';
 $string['linenum']  = 'Line <b>{$a}</b>: ';
+$string['notificationerror'] = 'Found {$a} errors';
+$string['notificationsuccess'] = 'Well done!';
 $string['privacy:metadata'] = 'The Moodle PHPdoc check plugin does not store any personal data.';
 
 $string['rule_noemptysecondline'] = 'Php open tag in the first line is not followed by empty line';

--- a/renderer.php
+++ b/renderer.php
@@ -33,6 +33,9 @@ defined('MOODLE_INTERNAL') || die;
  */
 class local_moodlecheck_renderer extends plugin_renderer_base {
 
+    /** @var int $errorcount */
+    protected $errorcount = 0;
+
     /**
      * Generates html to display one path validation results (invoked recursively)
      *
@@ -80,6 +83,7 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
     public function display_file_validation($filename, local_moodlecheck_file $file, $format = 'html') {
         $output = '';
         $errors = $file->validate();
+        $this->errorcount += count($errors);
         if ($format == 'html') {
             $output .= html_writer::start_tag('li', array('class' => 'file'));
             $output .= html_writer::tag('span', $filename, array('class' => 'filename'));
@@ -113,4 +117,17 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
         return $output;
     }
 
+    /**
+     * Display report summary
+     *
+     * @return string
+     */
+    public function display_summary() {
+        if ($this->errorcount > 0) {
+            return html_writer::tag('h2', get_string('notificationerror', 'local_moodlecheck', $this->errorcount),
+                ['class' => 'fail']);
+        } else {
+            return html_writer::tag('h2', get_string('notificationsuccess', 'local_moodlecheck'), ['class' => 'good']);
+        }
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,14 @@
     margin-top: 0;
 }
 
+.path-local-moodlecheck .fail {
+    color: #600;
+}
+
+.path-local-moodlecheck .good {
+    color: #060;
+}
+
 .path-local-moodlecheck form .fcheckbox label {
     margin-left: 1em;
 }


### PR DESCRIPTION
When running the tool over large plugins/areas of code, it would be helpful to see immediately the pass/fail summary (like codechecker does) instead of having to manually inspect the results