### PR TITLE
CONTRIB-8095 local_moodlecheck: Update inline tags handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,31 +19,37 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- 7.4
 
 env:
 - MOODLE_BRANCH=master           DB=pgsql
 - MOODLE_BRANCH=master           DB=mysqli
 - MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
 - MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
-- MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
 - MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
 
 matrix:
   exclude:
+  - php: 7.4
+    env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+  - php: 7.4
+    env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+  - php: 7.3
+    env: MOODLE_BRANCH=master           DB=mysqli
+  - php: 7.3
+    env: MOODLE_BRANCH=master           DB=pgsql
+  - php: 7.3
+    env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
   - php: 7.3
     env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=master           DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=master           DB=pgsql
   - php: 7.2
     env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
   - php: 7.2
     env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
-  - php: 7.2
-    env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
   - php: 7.1
-    env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    env: MOODLE_BRANCH=master           DB=mysqli
+  - php: 7.1
+    env: MOODLE_BRANCH=master           DB=pgsql
   - php: 7.1
     env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
   - php: 7.0
@@ -57,8 +63,8 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install 8.9
-  - nvm use 8.9
+  - nvm install 14
+  - nvm use 14
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"

--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -73,9 +73,12 @@ $string['rule_phpdocsinvalidinlinetag'] = 'Inline phpdocs tags are valid';
 $string['error_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tag not enclosed with curly brackets <b>{$a->tag}</b> found';
 $string['rule_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tags are enclosed with curly brackets';
 
+$string['error_phpdoccontentsinlinetag'] = 'Inline phpdocs tag <b>{$a->tag}</b> with incorrect contents found. It must match {@link valid URL} or {@see valid FDQN}';
+$string['rule_phpdoccontentsinlinetag'] = 'Inline phpdocs tags have correct contents';
 
 $string['error_functiondescription'] = 'There is no description in phpdocs for function <b>{$a->object}</b>';
 $string['rule_functiondescription'] = 'Functions have descriptions in phpdocs';
+
 $string['error_functionarguments'] = 'Phpdocs for function <b>{$a->function}</b> has incomplete parameters list';
 $string['rule_functionarguments'] = 'Phpdocs for functions properly define all parameters';
 

--- a/tests/fixtures/phpdoc_tags_inline.php
+++ b/tests/fixtures/phpdoc_tags_inline.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A fixture to verify various phpdoc tags are allowed inline.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+/**
+ * A fixture to verify various phpdoc tags can be used standalone or inline.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class fixturing_inline {
+
+    /**
+     * Some valid tags, to verify they are ok.
+     *
+     * @license
+     * @throws
+     * @deprecated
+     * @author
+     * @todo
+     * @codingStandardsIgnoreLine
+     */
+    public function all_valid_tags() {
+        echo "yay!";
+    }
+
+    /**
+     * Some tags that are valid standalone and inline
+     *
+     * @link https://moodle.org
+     * @see has_capability()
+     *
+     * To know more, visit {@link https://moodle.org} for Moodle info.
+     * To know more, take a look to {@see has_capability} about permissions.
+     * And verify that crazy {@see \so-me\com-plex\th_ing::come()->baby()} are ok too.
+     */
+    public function correct_inline_tags() {
+        echo "done!";
+    }
+
+    /**
+     * Some invalid inline tags.
+     *
+     * This tag {@param string Some param} cannot be used inline.
+     * Neither {@throws exception} can.
+     * Ideally all {@link tags have to be 1 url}.
+     * And all {@see must be 1 word only}
+     * Also they aren't valid without using @see curly brackets
+     */
+    public function all_invalid_tags() {
+        echo "done!";
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -152,4 +152,35 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertNotContains('@deprecated', $result);
         $this->assertNotContains('@codingStandardsIgnoreLine', $result);
     }
+
+    /**
+     * Verify various phpdoc tags can be used inline.
+     */
+    public function test_phpdoc_tags_inline() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_tags_inline.php ', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 2 children.
+        $expect = new DOMDocument();
+        $expect->loadXML('<file name="">' .
+                str_repeat('<error line="" severity="" message="" source=""/>', 7) .
+                '</file>');
+        $this->assertEqualXMLStructure($expect->firstChild, $xmlresult->firstChild, true);
+        // Also verify various bits by content.
+        $this->assertContains('packagevalid', $result);
+        $this->assertContains('Invalid inline phpdocs tag @param found', $result);
+        $this->assertContains('Invalid inline phpdocs tag @throws found', $result);
+        $this->assertContains('Inline phpdocs tag {@link tags have to be 1 url} with incorrect', $result);
+        $this->assertContains('Inline phpdocs tag {@see must be 1 word only} with incorrect', $result);
+        $this->assertContains('Inline phpdocs tag not enclosed with curly brackets @see found', $result);
+        $this->assertNotContains('{@link https://moodle.org}', $result);
+        $this->assertNotContains('{@see has_capability}', $result);
+        $this->assertNotContains('{@see see \so-me\com-plex\th_ing::come()->baby()}', $result);
+    }
 }


### PR DESCRIPTION
Add some new checks and tests to ensure that the handling
of inline tags (@link and @see) is correct and following the
agreement @ https://tracker.moodle.org/browse/MDLSITE-6105

- Both can be used standalone and inline
- @link always must be followed by url
- both @link and @see must be followed by only 1 word (url or fdqn)

Also, update travis to current supported php and moodle branches.