### PR TITLE
Add unit test for fetching the list of @category values

### DIFF
--- a/rules/coreapis.txt
+++ b/rules/coreapis.txt
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" class="client-nojs">
 <head>
-<meta charset="UTF-8"/>
+<meta charset="UTF-8"/><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"05ab6e1949",applicationID:"84455028"};window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var i=n[t]={exports:{}};e[t][0].call(i.exports,function(n){var i=e[t][1][n];return r(i||n)},i,i.exports)}return n[t].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<t.length;i++)r(t[i]);return r}({1:[function(e,n,t){function r(){}function i(e,n,t){return function(){return o(e,[u.now()].concat(c(arguments)),n?null:this,t),n?void 0:this}}var o=e("handle"),a=e(5),c=e(6),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,n){s[n]=i(p+n,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,i="function"==typeof n;return o(l+"tracer",[u.now(),e,t],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],t),i)try{return n.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],t),e}finally{f.emit("fn-end",[u.now()],t)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,n){m[n]=i(l+n)}),newrelic.noticeError=function(e,n){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,n])}},{}],2:[function(e,n,t){function r(e,n){var t=e.getEntries();t.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,n){var t=e.getEntries();t.length>0&&d("lcp",[t[t.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var n=Math.round(e.timeStamp),t={type:e.type};n<=p.now()?t.fid=p.now()-n:n>p.offset&&n<=Date.now()?(n-=p.offset,t.fid=p.now()-n):n=p.now(),g=!0,d("timing",["fi",n,t])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(4),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,y=["click","keydown","mousedown","pointerdown","touchstart"];y.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],3:[function(e,n,t){function r(e,n){if(!i)return!1;if(e!==i)return!1;if(!n)return!0;if(!o)return!1;for(var t=o.split("."),r=n.split("."),a=0;a<r.length;a++)if(r[a]!==t[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}n.exports={agent:i,version:o,match:r}},{}],4:[function(e,n,t){function r(e){function n(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,n,!1)}n.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],5:[function(e,n,t){function r(e,n){var t=[],r="",o=0;for(r in e)i.call(e,r)&&(t[o]=n(r,e[r]),o+=1);return t}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],6:[function(e,n,t){function r(e,n,t){n||(n=0),"undefined"==typeof t&&(t=e?e.length:0);for(var r=-1,i=t-n||0,o=Array(i<0?0:i);++r<i;)o[r]=e[n+r];return o}n.exports=r},{}],7:[function(e,n,t){n.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function i(e){function n(e){return e&&e instanceof r?e:e?f(e,c,o):o()}function t(t,r,i,o){if(!p.aborted||o){e&&e(t,r,i);for(var a=n(i),c=v(t),f=c.length,u=0;u<f;u++)c[u].apply(a,r);var d=s[w[t]];return d&&d.push([b,t,r,a]),a}}function l(e,n){h[e]=v(e).concat(n)}function m(e,n){var t=h[e];if(t)for(var r=0;r<t.length;r++)t[r]===n&&t.splice(r,1)}function v(e){return h[e]||[]}function g(e){return d[e]=d[e]||i(t)}function y(e,n){u(e,function(e,t){n=n||"feature",w[t]=n,n in s||(s[n]=[])})}var h={},w={},b={on:l,addEventListener:l,removeEventListener:m,emit:t,get:g,listeners:v,context:n,buffer:y,abort:a,aborted:!1};return b}function o(){return new r}function a(){(s.api||s.feature)&&(p.aborted=!0,s=p.backlog={})}var c="nr@context",f=e("gos"),u=e(5),s={},d={},p=n.exports=i();p.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(i.call(e,n))return e[n];var r=t();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[n]=r,r}var i=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){i.buffer([e],r),i.emit(e,n,t)}var i=e("ee").get("handle");n.exports=r,r.ee=i},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||"object"!==n&&"function"!==n?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=E.info=NREUM.info,n=l.getElementsByTagName("script")[0];if(setTimeout(s.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&n))return s.abort();u(w,function(n,t){e[n]||(e[n]=t)});var t=a();f("mark",["onload",t+E.offset],null,"api"),f("timing",["load",t]);var r=l.createElement("script");r.src="https://"+e.agent,n.parentNode.insertBefore(r,n)}}function i(){"complete"===l.readyState&&o()}function o(){f("mark",["domContent",a()+E.offset],null,"api")}function a(){return O.exists&&performance.now?Math.round(performance.now()):(c=Math.max((new Date).getTime(),c))-E.offset}var c=(new Date).getTime(),f=e("handle"),u=e(5),s=e("ee"),d=e(3),p=window,l=p.document,m="addEventListener",v="attachEvent",g=p.XMLHttpRequest,y=g&&g.prototype;NREUM.o={ST:setTimeout,SI:p.setImmediate,CT:clearTimeout,XHR:g,REQ:p.Request,EV:p.Event,PR:p.Promise,MO:p.MutationObserver};var h=""+location,w={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1177.min.js"},b=g&&y&&y[m]&&!/CriOS/.test(navigator.userAgent),E=n.exports={offset:c,now:a,origin:h,features:{},xhrWrappable:b,userAgent:d};e(1),e(2),l[m]?(l[m]("DOMContentLoaded",o,!1),p[m]("load",r,!1)):(l[v]("onreadystatechange",i),p[v]("onload",r)),f("mark",["firstbyte",c],null,"api");var x=0,O=e(7)},{}],"wrap-function":[function(e,n,t){function r(e){return!(e&&e instanceof Function&&e.apply&&!e[a])}var i=e("ee"),o=e(6),a="nr@original",c=Object.prototype.hasOwnProperty,f=!1;n.exports=function(e,n){function t(e,n,t,i){function nrWrapper(){var r,a,c,f;try{a=this,r=o(arguments),c="function"==typeof t?t(r,a):t||{}}catch(u){p([u,"",[r,a,i],c])}s(n+"start",[r,a,i],c);try{return f=e.apply(a,r)}catch(d){throw s(n+"err",[r,a,d],c),d}finally{s(n+"end",[r,a,f],c)}}return r(e)?e:(n||(n=""),nrWrapper[a]=e,d(e,nrWrapper),nrWrapper)}function u(e,n,i,o){i||(i="");var a,c,f,u="-"===i.charAt(0);for(f=0;f<n.length;f++)c=n[f],a=e[c],r(a)||(e[c]=t(a,u?c+i:i,o,c))}function s(t,r,i){if(!f||n){var o=f;f=!0;try{e.emit(t,r,i,n)}catch(a){p([a,t,r,i])}f=o}}function d(e,n){if(Object.defineProperty&&Object.keys)try{var t=Object.keys(e);return t.forEach(function(t){Object.defineProperty(n,t,{get:function(){return e[t]},set:function(n){return e[t]=n,n}})}),n}catch(r){p([r])}for(var i in e)c.call(e,i)&&(n[i]=e[i]);return n}function p(n){try{e.emit("internal-error",n)}catch(t){}}return e||(e=i),t.inPlace=u,t.flag=a,t}},{}]},{},["loader"]);</script>
 <title>Core APIs - MoodleDocs</title>
 <script>document.documentElement.className = document.documentElement.className.replace( /(^|\s)client-nojs(\s|$)/, "$1client-js$2" );</script>
-<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Core_APIs","wgTitle":"Core APIs","wgCurRevisionId":57550,"wgRevisionId":57550,"wgArticleId":3684,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"Core_APIs","wgRelevantArticleId":3684,"wgRequestId":"e5f06a461fb3cb0920e78bbb","wgIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgWikiEditorEnabledModules":{"toolbar":true,"dialogs":false,"preview":false,"publish":false}});mw.loader.implement("user.options",function($,jQuery,require,module){mw.user.options.set({"variant":"en"});});mw.loader.implement("user.tokens",function ( $, jQuery, require, module ) {
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Core_APIs","wgTitle":"Core APIs","wgCurRevisionId":57824,"wgRevisionId":57824,"wgArticleId":3684,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"Core_APIs","wgRelevantArticleId":3684,"wgRequestId":"527246c6114ced3ab41c7308","wgIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgWikiEditorEnabledModules":{"toolbar":true,"dialogs":false,"preview":false,"publish":false}});mw.loader.implement("user.options",function($,jQuery,require,module){mw.user.options.set({"variant":"en"});});mw.loader.implement("user.tokens",function ( $, jQuery, require, module ) {
 mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});/*@nomin*/;
 
 });mw.loader.load(["mediawiki.page.startup"]);});</script>
@@ -101,9 +101,9 @@ mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","cs
 </li>
 <li class="toclevel-1 tocsection-13"><a href="#Other_General_APIs"><span class="tocnumber">2</span> <span class="toctext">Other General APIs</span></a>
 <ul>
-<li class="toclevel-2 tocsection-14"><a href="#Admin_settings_.28admin.29"><span class="tocnumber">2.1</span> <span class="toctext">Admin settings (admin)</span></a></li>
+<li class="toclevel-2 tocsection-14"><a href="#Admin_settings_API_.28admin.29"><span class="tocnumber">2.1</span> <span class="toctext">Admin settings API (admin)</span></a></li>
 <li class="toclevel-2 tocsection-15"><a href="#Analytics_API_.28analytics.29"><span class="tocnumber">2.2</span> <span class="toctext">Analytics API (analytics)</span></a></li>
-<li class="toclevel-2 tocsection-16"><a href="#Availability_.28availability.29"><span class="tocnumber">2.3</span> <span class="toctext">Availability (availability)</span></a></li>
+<li class="toclevel-2 tocsection-16"><a href="#Availability_API_.28availability.29"><span class="tocnumber">2.3</span> <span class="toctext">Availability API (availability)</span></a></li>
 <li class="toclevel-2 tocsection-17"><a href="#Backup_API_.28backup.29"><span class="tocnumber">2.4</span> <span class="toctext">Backup API (backup)</span></a></li>
 <li class="toclevel-2 tocsection-18"><a href="#Cache_API_.28cache.29"><span class="tocnumber">2.5</span> <span class="toctext">Cache API (cache)</span></a></li>
 <li class="toclevel-2 tocsection-19"><a href="#Calendar_API_.28calendar.29"><span class="tocnumber">2.6</span> <span class="toctext">Calendar API (calendar)</span></a></li>
@@ -134,7 +134,7 @@ mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","cs
 <li class="toclevel-2 tocsection-44"><a href="#Testing_API_.28test.29"><span class="tocnumber">2.31</span> <span class="toctext">Testing API (test)</span></a></li>
 <li class="toclevel-2 tocsection-45"><a href="#User-related_APIs_.28user.29"><span class="tocnumber">2.32</span> <span class="toctext">User-related APIs (user)</span></a></li>
 <li class="toclevel-2 tocsection-46"><a href="#Web_services_API_.28webservice.29"><span class="tocnumber">2.33</span> <span class="toctext">Web services API (webservice)</span></a></li>
-<li class="toclevel-2 tocsection-47"><a href="#Badges_API_.28OpenBadges.29"><span class="tocnumber">2.34</span> <span class="toctext">Badges API (OpenBadges)</span></a></li>
+<li class="toclevel-2 tocsection-47"><a href="#Badges_API_.28badges.29"><span class="tocnumber">2.34</span> <span class="toctext">Badges API (badges)</span></a></li>
 <li class="toclevel-2 tocsection-48"><a href="#Custom_fields_API"><span class="tocnumber">2.35</span> <span class="toctext">Custom fields API</span></a></li>
 </ul>
 </li>
@@ -190,13 +190,13 @@ mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","cs
 <p>The <a href="/dev/index.php?title=Moodlelib_API&amp;action=edit&amp;redlink=1" class="new" title="Moodlelib API (page does not exist)">Moodlelib API</a> is the central library file of miscellaneous general-purpose Moodle functions. Functions can over the handling of request parameters, configs, user preferences, time, login, mnet, plugins, strings and others. There are plenty of defined constants too.
 </p>
 <h2><span class="mw-headline" id="Other_General_APIs">Other General APIs</span></h2>
-<h3><span class="mw-headline" id="Admin_settings_.28admin.29">Admin settings (admin)</span></h3>
+<h3><span class="mw-headline" id="Admin_settings_API_.28admin.29">Admin settings API (admin)</span></h3>
 <p>The <a href="/dev/Admin_settings" title="Admin settings">Admin settings</a> API deals with providing configuration options for each plugin and Moodle core.
 </p>
 <h3><span class="mw-headline" id="Analytics_API_.28analytics.29">Analytics API (analytics)</span></h3>
 <p>The <a href="/dev/Analytics_API" title="Analytics API">Analytics API</a> allow you to create prediction models and generate insights.
 </p>
-<h3><span class="mw-headline" id="Availability_.28availability.29">Availability (availability)</span></h3>
+<h3><span class="mw-headline" id="Availability_API_.28availability.29">Availability API (availability)</span></h3>
 <p>The <a href="/dev/Availability_API" title="Availability API">Availability API</a> controls access to activities and sections.
 </p>
 <h3><span class="mw-headline" id="Backup_API_.28backup.29">Backup API (backup)</span></h3>
@@ -209,7 +209,7 @@ mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","cs
 <p>The <a href="/dev/Calendar_API" title="Calendar API">Calendar API</a> allows you to add and modify events in the calendar for user, groups, courses, or the whole site.
 </p>
 <h3><span class="mw-headline" id="Check_API_.28check.29">Check API (check)</span></h3>
-<p>WIP The <a href="/dev/Check_API" title="Check API">Check API</a> allows you to add security, performance or health checks to your site.
+<p>The <a href="/dev/Check_API" title="Check API">Check API</a> allows you to add security, performance or health checks to your site.
 </p>
 <h3><span class="mw-headline" id="Comment_API_.28comment.29">Comment API (comment)</span></h3>
 <p>The <a href="/dev/Comment_API" title="Comment API">Comment API</a> allows you to save and retrieve user comments, so that you can easily add commenting to any of your code.
@@ -291,7 +291,7 @@ This allows compliance with regulation such as the General Data Protection Regul
 <h3><span class="mw-headline" id="Web_services_API_.28webservice.29">Web services API (webservice)</span></h3>
 <p>The <a href="/dev/Web_services_API" title="Web services API">Web services API</a> allows you to expose particular functions (usually external functions) as web services.
 </p>
-<h3><span class="mw-headline" id="Badges_API_.28OpenBadges.29">Badges API (OpenBadges)</span></h3>
+<h3><span class="mw-headline" id="Badges_API_.28badges.29">Badges API (badges)</span></h3>
 <p>The <a rel="nofollow" class="external text" href="https://docs.moodle.org/dev/OpenBadges_User_Documentation">Badges</a> user documentation (is a temp page until we compile a proper page with all the classes and APIs that allows you to manage particular badges and OpenBadges Backpack).
 </p>
 <h3><span class="mw-headline" id="Custom_fields_API">Custom fields API</span></h3>
@@ -328,11 +328,11 @@ This allows compliance with regulation such as the General Data Protection Regul
 
 <!-- 
 NewPP limit report
-Cached time: 20200528184113
+Cached time: 20200906145321
 Cache expiry: 86400
 Dynamic content: false
-CPU time usage: 0.012 seconds
-Real time usage: 0.011 seconds
+CPU time usage: 0.020 seconds
+Real time usage: 0.064 seconds
 Preprocessor visited node count: 227/1000000
 Preprocessor generated node count: 232/1000000
 Post‐expand include size: 0/2097152 bytes
@@ -346,10 +346,10 @@ Transclusion expansion time report (%,ms,calls,template)
 100.00%    0.000      1 - -total
 -->
 
-<!-- Saved in parser cache with key docs_development:pcache:idhash:3684-0!*!0!!en!*!* and timestamp 20200528184113 and revision id 57550
+<!-- Saved in parser cache with key docs_development:pcache:idhash:3684-0!*!0!!en!*!* and timestamp 20200906145321 and revision id 57824
  -->
 </div><div class="printfooter">
-Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=Core_APIs&amp;oldid=57550">https://docs.moodle.org/dev/index.php?title=Core_APIs&amp;oldid=57550</a>"</div>
+Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=Core_APIs&amp;oldid=57824">https://docs.moodle.org/dev/index.php?title=Core_APIs&amp;oldid=57824</a>"</div>
 		<div id="catlinks" class="catlinks catlinks-allhidden" data-mw="interface"></div>		<!-- end content -->
 				<div class="visualClear"></div>
 	</div>
@@ -383,7 +383,7 @@ Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=C
 				<li id="t-whatlinkshere"><a href="/dev/Special:WhatLinksHere/Core_APIs" title="A list of all wiki pages that link here [j]" accesskey="j">What links here</a></li>
 				<li id="t-recentchangeslinked"><a href="/dev/Special:RecentChangesLinked/Core_APIs" title="Recent changes in pages linked from this page [k]" accesskey="k">Related changes</a></li>
 <li id="t-specialpages"><a href="/dev/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q">Special pages</a></li>
-				<li id="t-print"><a href="/dev/index.php?title=Core_APIs&amp;printable=yes" rel="alternate" title="Printable version of this page [p]" accesskey="p">Printable version</a></li>				<li id="t-permalink"><a href="/dev/index.php?title=Core_APIs&amp;oldid=57550" title="Permanent link to this revision of the page">Permanent link</a></li>			</ul>
+				<li id="t-print"><a href="/dev/index.php?title=Core_APIs&amp;printable=yes" rel="alternate" title="Printable version of this page [p]" accesskey="p">Printable version</a></li>				<li id="t-permalink"><a href="/dev/index.php?title=Core_APIs&amp;oldid=57824" title="Permanent link to this revision of the page">Permanent link</a></li>			</ul>
 		</div>
 	</div>
 <div id="p-search" role="search">
@@ -401,7 +401,7 @@ Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=C
 		<a href="//www.mediawiki.org/"><img src="/dev/resources/assets/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/dev/resources/assets/poweredby_mediawiki_132x47.png 1.5x, /dev/resources/assets/poweredby_mediawiki_176x62.png 2x" width="88" height="31"/></a>
 	</div>
 	<ul id="f-list">
-		<li id="lastmod"> This page was last modified on 28 May 2020, at 15:24.</li>
+		<li id="lastmod"> This page was last modified on 4 September 2020, at 10:09.</li>
 		<li id="copyright">Content is available under <a class="external" rel="nofollow" href="https://docs.moodle.org/dev/License">GNU General Public License</a> unless otherwise noted.</li>
 		<li id="privacy"><a href="/dev/MoodleDocs:Privacy_policy" title="MoodleDocs:Privacy policy">Privacy</a></li>
 		<li id="about"><a href="/dev/MoodleDocs:About" title="MoodleDocs:About">About the Dev docs</a></li>
@@ -409,7 +409,7 @@ Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=C
 	</ul>
 </div>
 </div>
-<script>(window.RLQ=window.RLQ||[]).push(function(){mw.loader.state({"user":"ready","user.groups":"ready"});mw.loader.load(["mediawiki.toc","mediawiki.action.view.postEdit","site","mediawiki.user","mediawiki.hidpi","mediawiki.page.ready","mediawiki.searchSuggest","custom.editortoolbar","ext.moderation.notify","ext.moderation.notify.desktop","skins.moodledocs.bootstrap"]);});</script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":69});});</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.loader.state({"user":"ready","user.groups":"ready"});mw.loader.load(["mediawiki.toc","mediawiki.action.view.postEdit","site","mediawiki.user","mediawiki.hidpi","mediawiki.page.ready","mediawiki.searchSuggest","custom.editortoolbar","ext.moderation.notify","ext.moderation.notify.desktop","skins.moodledocs.bootstrap"]);});</script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":251});});</script>
 <!-- final footer start -->
 <div id="moodlesitelink"></div>
 <!-- final footer end -->
@@ -419,4 +419,4 @@ Retrieved from "<a dir="ltr" href="https://docs.moodle.org/dev/index.php?title=C
 <script type="text/javascript">var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));</script><script type="text/javascript">try {var pageTracker = _gat._getTracker("UA-72764-4");pageTracker._trackPageview();} catch(err) {}</script>
 <!-- google analytics end -->
 
-</body></html>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"05ab6e1949","applicationID":"84455028","transactionName":"YwBabBRSCEFYAkVaWlpKeVsSWglcFgBSR1xbCxdOD1YR","queueTime":0,"applicationTime":252,"atts":"T0dZGlxIG08=","errorBeacon":"bam.nr-data.net","agent":""}</script></body></html>

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -199,11 +199,11 @@ function &local_moodlecheck_get_categories() {
             $allcategories = explode(',', $lastsavedvalue);
         } else {
             $allcategories = array();
-            $filecontent = @file_get_contents("http://docs.moodle.org/dev/Core_APIs");
+            $filecontent = @file_get_contents("https://docs.moodle.org/dev/Core_APIs");
             if (!$filecontent) {
                 $filecontent = file_get_contents($CFG->dirroot . '/local/moodlecheck/rules/coreapis.txt');
             }
-            preg_match_all('|<span class="mw-headline".*>.*API\s*\((.*)\)\s*</span>|i', $filecontent, $matches);
+            preg_match_all('|<span\s*.*\s*class="mw-headline".*>.*API\s*\((.*)\)\s*</span>|i', $filecontent, $matches);
             foreach ($matches[1] as $match) {
                 $allcategories[] = trim(strip_tags(strtolower($match)));
             }

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -184,11 +184,11 @@ function &local_moodlecheck_get_plugins() {
 /**
  * Reads the list of Core APIs from internet (or local copy) and returns the list of categories
  *
- * Also caches the list
+ * @param bool $forceoffline Disable fetching from the live docs site, useful for testing.
  *
  * @return array
  */
-function &local_moodlecheck_get_categories() {
+function &local_moodlecheck_get_categories($forceoffline = false) {
     global $CFG;
     static $allcategories = array();
     if (empty($allcategories)) {
@@ -199,8 +199,11 @@ function &local_moodlecheck_get_categories() {
             $allcategories = explode(',', $lastsavedvalue);
         } else {
             $allcategories = array();
-            $filecontent = @file_get_contents("https://docs.moodle.org/dev/Core_APIs");
-            if (!$filecontent) {
+            $filecontent = false;
+            if (!$forceoffline) {
+                $filecontent = @file_get_contents("https://docs.moodle.org/dev/Core_APIs");
+            }
+            if (empty($filecontent)) {
                 $filecontent = file_get_contents($CFG->dirroot . '/local/moodlecheck/rules/coreapis.txt');
             }
             preg_match_all('|<span\s*.*\s*class="mw-headline".*>.*API\s*\((.*)\)\s*</span>|i', $filecontent, $matches);

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -185,4 +185,26 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertNotContains('{@see has_capability}', $result);
         $this->assertNotContains('baby}', $result);
     }
+
+    /**
+     * Test that {@see local_moodlecheck_get_categories()} returns the correct list of allowed categories.
+     */
+    public function test_local_moodlecheck_get_categories() {
+
+        set_user_preference('local_moodlecheck_categoriestime', 0);
+        set_user_preference('local_moodlecheck_categoriesvalue', '');
+
+        $allowed = local_moodlecheck_get_categories();
+
+        $expected = ['access', 'dml', 'files', 'form', 'log', 'navigation', 'page', 'output', 'string', 'upgrade',
+            'core', 'admin', 'analytics', 'availability', 'backup', 'cache', 'calendar', 'check', 'comment',
+            'competency', 'ddl', 'enrol', 'event', 'xapi', 'external', 'lock', 'message', 'media', 'oauth2',
+            'preference', 'portfolio', 'privacy', 'rating', 'rss', 'search', 'tag', 'task', 'time', 'test',
+            'webservice', 'badges', 'completion', 'grading', 'group', 'grade', 'plagiarism', 'question',
+        ];
+
+        foreach ($expected as $category) {
+            $this->assertContains($category, $allowed);
+        }
+    }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -206,5 +206,12 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         foreach ($expected as $category) {
             $this->assertContains($category, $allowed);
         }
+
+        // Also check that the locally cached copy is still up to date.
+        $allowed = local_moodlecheck_get_categories(true);
+
+        foreach ($expected as $category) {
+            $this->assertContains($category, $allowed);
+        }
     }
 }


### PR DESCRIPTION
It raised my attention to see that I got an error
https://integration.moodle.org/job/Precheck%20remote%20branch/92421/artifact/work/smurf.html#phpdoc

"Category admin is not valid"

even when the "admin" should be considered valid core API. I realized the reason was that the heading in the docs was

```
=== Admin settings (admin) ===
```

and because there was no "API" mentioned in it, the "admin" was not parsed as a valid category value.

I was able to fix this easily by changing the section title in the docs (and one another, too) -  https://docs.moodle.org/dev/index.php?title=Core_APIs&type=revision&diff=57824&oldid=57817

However, I thought it would be nice to have the check covered by a unit test so I added one.

Also fix the docs page URL and make the regexp search a bit more robust
just in case the HTML change a bit.