### PR TITLE
Anonymous class phpdoc

### DIFF
--- a/file.php
+++ b/file.php
@@ -193,9 +193,23 @@ class local_moodlecheck_file {
                         continue;
                     }
 
-                    if ($this->previous_nonspace_token($tid) == 'new' && $this->next_nonspace_token($tid) == 'extends') {
-                        // Skip anonymous classes.
-                        continue;
+                    if ($this->previous_nonspace_token($tid) == 'new') {
+                        // This looks to be an anonymous class.
+
+                        if ($this->next_nonspace_token($tid) == '{') {
+                            // An anonymous class in the format `new class {`.
+                            continue;
+                        }
+
+                        if ($this->next_nonspace_token($tid) == 'extends') {
+                            // An anonymous class in the format `new class extends otherclasses {`.
+                            continue;
+                        }
+
+                        if ($this->next_nonspace_token($tid) == 'implements') {
+                            // An anonymous class in the format `new class implements someinterface {`.
+                            continue;
+                        }
                     }
                     $class = new stdClass();
                     $class->tid = $tid;

--- a/file.php
+++ b/file.php
@@ -188,6 +188,11 @@ class local_moodlecheck_file {
             $tokens = &$this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if (($this->tokens[$tid][0] == T_CLASS) && ($this->previous_nonspace_token($tid) !== "::")) {
+                    // Skip anonymous classes.
+                    if (($this->previous_nonspace_token($tid) == 'new') and
+                            ($this->next_nonspace_token($tid) == 'extends')) {
+                        continue;
+                    }
                     $class = new stdClass();
                     $class->tid = $tid;
                     $class->name = $this->next_nonspace_token($tid);

--- a/file.php
+++ b/file.php
@@ -187,10 +187,14 @@ class local_moodlecheck_file {
             $this->classes = array();
             $tokens = &$this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
-                if (($this->tokens[$tid][0] == T_CLASS) && ($this->previous_nonspace_token($tid) !== "::")) {
-                    // Skip anonymous classes.
-                    if (($this->previous_nonspace_token($tid) == 'new') and
-                            ($this->next_nonspace_token($tid) == 'extends')) {
+                if ($this->tokens[$tid][0] == T_CLASS) {
+                    if ($this->previous_nonspace_token($tid) === "::") {
+                        // Skip use of the ::class special constant.
+                        continue;
+                    }
+
+                    if ($this->previous_nonspace_token($tid) == 'new' && $this->next_nonspace_token($tid) == 'extends') {
+                        // Skip anonymous classes.
                         continue;
                     }
                     $class = new stdClass();

--- a/tests/fixtures/anonymous/anonymous.php
+++ b/tests/fixtures/anonymous/anonymous.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class {
+};

--- a/tests/fixtures/anonymous/assigned.php
+++ b/tests/fixtures/anonymous/assigned.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$value = new class {
+};

--- a/tests/fixtures/anonymous/extends.php
+++ b/tests/fixtures/anonymous/extends.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class extends parentclass {
+};

--- a/tests/fixtures/anonymous/extendsandimplements.php
+++ b/tests/fixtures/anonymous/extendsandimplements.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class extends parentclass implements someinterface {
+};

--- a/tests/fixtures/anonymous/implements.php
+++ b/tests/fixtures/anonymous/implements.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class implements someinterface {
+};

--- a/tests/fixtures/anonymous/named.php
+++ b/tests/fixtures/anonymous/named.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2020 Andrew Nicols <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_moodlecheck\test\fixtures\anonymous;
+
+class someclass extends parentclass {
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -26,7 +26,6 @@
 
 defined('MOODLE_INTERNAL') || die(); // Remove this to use me out from Moodle.
 
-
 class local_moodlecheck_rules_testcase extends advanced_testcase {
 
     public function setUp() {
@@ -184,5 +183,45 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertNotContains('{@link https://moodle.org}', $result);
         $this->assertNotContains('{@see has_capability}', $result);
         $this->assertNotContains('baby}', $result);
+    }
+
+    /**
+     * Verify that anonymous classes do not require phpdoc class blocks.
+     *
+     * @dataProvider anonymous_class_provider
+     * @param   string $path
+     * @param   bool $expectclassesdocumentedfail Whether the
+     */
+    public function test_phpdoc_anonymous_class_docblock(string $path, bool $expectclassesdocumentedfail) {
+        global $PAGE;
+
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $checkpath = new local_moodlecheck_path($path, null);
+        $result = $output->display_path($checkpath, 'xml');
+
+        if ($expectclassesdocumentedfail) {
+            $this->assertContains('classesdocumented', $result);
+        } else {
+            $this->assertNotContains('classesdocumented', $result);
+        }
+    }
+
+    /**
+     * Data provider for anonymous classes tests.
+     *
+     * @return  array
+     */
+    public function anonymous_class_provider(): array {
+        $rootpath  = 'local/moodlecheck/tests/fixtures/anonymous';
+        return [
+            'return new class extends parentclass {' => [
+                "{$rootpath}/extends.php",
+                false,
+            ],
+            'class someclass extends parentclass {' => [
+                "{$rootpath}/named.php",
+                true,
+            ],
+        ];
     }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -214,8 +214,24 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
     public function anonymous_class_provider(): array {
         $rootpath  = 'local/moodlecheck/tests/fixtures/anonymous';
         return [
+            'return new class {' => [
+                "{$rootpath}/anonymous.php",
+                false,
+            ],
             'return new class extends parentclass {' => [
                 "{$rootpath}/extends.php",
+                false,
+            ],
+            'return new class implements someinterface {' => [
+                "{$rootpath}/implements.php",
+                false,
+            ],
+            'return new class extends parentclass implements someinterface {' => [
+                "{$rootpath}/extendsandimplements.php",
+                false,
+            ],
+            '$value = new class {' => [
+                "{$rootpath}/assigned.php",
                 false,
             ],
             'class someclass extends parentclass {' => [


### PR DESCRIPTION
Do not require docblocks for anonymous classes.

Anonymous classes were introduced in PHP 7.0, and are used by Moodle's code coverage configuration.

Fixes #50

Note: This original patch was by @ewallah in #51, but I have made the following changes:
- remove unnecessary Travis configuration
- remove merge commit
- add unit tests
- meet coding style
- add additional cases (no extension, and implementing interfaces)