### PR TITLE
Digits can be used in classes and functions names

### DIFF
--- a/file.php
+++ b/file.php
@@ -1150,7 +1150,7 @@ class local_moodlecheck_phpdocs {
         if ($substring === null) {
             return $line0;
         } else {
-            $chunks = preg_split('!' . $substring . '!', $this->originaltoken[1]);
+            $chunks = preg_split('!' . preg_quote($substring, '!') . '!', $this->originaltoken[1]);
             if (count($chunks) > 1) {
                 $lines = preg_split('/\n/', $chunks[0]);
                 return $line0 + count($lines) - 1;

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -329,7 +329,7 @@ function local_moodlecheck_phpdoccontentsinlinetag(local_moodlecheck_file $file)
                             }
                             break;
                         case 'see': // Must be 1-word (with some chars allowed - FQSEN only.
-                            if (str_word_count($content, 0, '\()-_:>$') !== 1) {
+                            if (str_word_count($content, 0, '\()-_:>$012345789') !== 1) {
                                 $errors[] = array(
                                     'line' => $phpdocs->get_line_number($file, ' {@' . $curlyinlinetag),
                                     'tag' => '{@' . $curlyinlinetag . '}');


### PR DESCRIPTION
I got this error in codechecker:

```
 Inline phpdocs tag {@see \auth_oauth2\auth::complete_login()} with incorrect contents found. It must match {@link valid URL} or {@see valid FQSEN}
```

There is nothing wrong here but apparently moodlecheck treats digits as word separators