### PR TITLE
Update tests to phpunit 8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,86 +1,67 @@
 language: php
 
-sudo: false
-
-addons:
-  firefox: "47.0.1"
-  postgresql: "9.6"
+os: linux
+dist: xenial
 
 services:
-  mysql
+  - mysql
+  - postgresql
+  - docker
 
 cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.npm
+    - $HOME/.nvm
 
-php:
-- 7.0
-- 7.1
-- 7.2
-- 7.3
-- 7.4
+jobs:
+  include:
+    - php: 7.4
+      env: MOODLE_BRANCH=master            DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=master            DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
 
-env:
-- MOODLE_BRANCH=master            DB=pgsql
-- MOODLE_BRANCH=master            DB=mysqli
-- MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
-- MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
-- MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
-- MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
-- MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
-- MOODLE_BRANCH=MOODLE_35_STABLE  DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=master            DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=master            DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
 
-matrix:
-  exclude:
-  - php: 7.4
-    env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
-  - php: 7.4
-    env: MOODLE_BRANCH=MOODLE_35_STABLE  DB=mysqli
-  - php: 7.3
-    env: MOODLE_BRANCH=master            DB=mysqli
-  - php: 7.3
-    env: MOODLE_BRANCH=master            DB=pgsql
-  - php: 7.3
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
-  - php: 7.3
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
-  - php: 7.3
-    env: MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
-  - php: 7.3
-    env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
-  - php: 7.3
-    env: MOODLE_BRANCH=MOODLE_35_STABLE  DB=mysqli
-  - php: 7.2
-    env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
-  - php: 7.2
-    env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=master            DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=master            DB=pgsql
-  - php: 7.1
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
-  - php: 7.1
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
-  - php: 7.1
-    env: MOODLE_BRANCH=MOODLE_35_STABLE  DB=mysqli
-  - php: 7.0
-    env: MOODLE_BRANCH=master            DB=mysqli
-  - php: 7.0
-    env: MOODLE_BRANCH=master            DB=pgsql
-  - php: 7.0
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
-  - php: 7.0
-    env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
-  - php: 7.0
-    env: MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
-  - php: 7.0
-    env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
-  - php: 7.0
-    env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_39_STABLE  DB=mysqli
+
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
+
+    # Cannot test with Moodle 3.2 and 3.3 any more because the new composer 2
+    # does require all components to be named properly (case-sensitively) and
+    # those branches have phpunit/Dbunit, failing. See MDL-64725.
+
+    # Cannot test with Moodle 3.4, 3.5, 3.6 because the use phpunit 6.x that
+    # does not contain the new stringContainsString() assertions.
+
+    # Cannot test with PHP 7.0 any more because we are now using the :void return type.
+    # Note that, still, the plugin will work ok, it's just the phpunit tests which cannot
+    # be executed with that PHP versions.
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -100,4 +81,6 @@ script:
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
+  #- moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat

--- a/tests/fixtures/phpdoc_tags_inline.php
+++ b/tests/fixtures/phpdoc_tags_inline.php
@@ -57,7 +57,7 @@ class fixturing_inline {
      *
      * To know more, visit {@link https://moodle.org} for Moodle info.
      * To know more, take a look to {@see has_capability} about permissions.
-     * And verify that crazy {@see \so-me\com-plex\th_ing::$come->baby()} are ok too.
+     * And verify that crazy {@see \so-me\com-plex\th_ing::$come->ba8by()} are ok too.
      */
     public function correct_inline_tags() {
         echo "done!";

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die(); // Remove this to use me out from Moodle.
 
 class local_moodlecheck_rules_testcase extends advanced_testcase {
 
-    public function setUp() {
+    public function setUp(): void {
         global $CFG;
         parent::setUp();
         // Add the moodlecheck machinery.
@@ -69,10 +69,10 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
                 '</file>');
         $this->assertEqualXMLStructure($expect->firstChild, $xmlresult->firstChild, true);
         // Also verify that contents do not include any problem with line 42 / classesdocumented. Use simple string matching here.
-        $this->assertContains('line="20"', $result);
-        $this->assertContains('packagevalid', $result);
-        $this->assertNotContains('line="42"', $result);
-        $this->assertNotContains('classesdocumented', $result);
+        $this->assertStringContainsString('line="20"', $result);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringNotContainsString('line="42"', $result);
+        $this->assertStringNotContainsString('classesdocumented', $result);
     }
 
     /**
@@ -86,8 +86,8 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
 
         $result = $output->display_path($path, 'xml');
 
-        $this->assertNotContains('classeshavecopyright', $result);
-        $this->assertNotContains('classeshavelicense', $result);
+        $this->assertStringNotContainsString('classeshavecopyright', $result);
+        $this->assertStringNotContainsString('classeshavelicense', $result);
     }
 
     /**
@@ -110,15 +110,15 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
                 '</file>');
         $this->assertEqualXMLStructure($expect->firstChild, $xmlresult->firstChild, true);
         // Also verify various bits by content.
-        $this->assertContains('packagevalid', $result);
-        $this->assertContains('Invalid phpdocs tag @small', $result);
-        $this->assertContains('Invalid phpdocs tag @zzzing', $result);
-        $this->assertContains('Invalid phpdocs tag @inheritdoc', $result);
-        $this->assertContains('Incorrect path for phpdocs tag @covers', $result);
-        $this->assertContains('Incorrect path for phpdocs tag @dataProvider', $result);
-        $this->assertContains('Incorrect path for phpdocs tag @group', $result);
-        $this->assertNotContains('@deprecated', $result);
-        $this->assertNotContains('@codingStandardsIgnoreLine', $result);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @small', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @zzzing', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @inheritdoc', $result);
+        $this->assertStringContainsString('Incorrect path for phpdocs tag @covers', $result);
+        $this->assertStringContainsString('Incorrect path for phpdocs tag @dataProvider', $result);
+        $this->assertStringContainsString('Incorrect path for phpdocs tag @group', $result);
+        $this->assertStringNotContainsString('@deprecated', $result);
+        $this->assertStringNotContainsString('@codingStandardsIgnoreLine', $result);
     }
 
     /**
@@ -141,15 +141,15 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
                 '</file>');
         $this->assertEqualXMLStructure($expect->firstChild, $xmlresult->firstChild, true);
         // Also verify various bits by content.
-        $this->assertContains('packagevalid', $result);
-        $this->assertContains('Invalid phpdocs tag @small', $result);
-        $this->assertContains('Invalid phpdocs tag @zzzing', $result);
-        $this->assertContains('Invalid phpdocs tag @inheritdoc', $result);
-        $this->assertNotContains('Incorrect path for phpdocs tag @covers', $result);
-        $this->assertNotContains('Incorrect path for phpdocs tag @dataProvider', $result);
-        $this->assertNotContains('Incorrect path for phpdocs tag @group', $result);
-        $this->assertNotContains('@deprecated', $result);
-        $this->assertNotContains('@codingStandardsIgnoreLine', $result);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @small', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @zzzing', $result);
+        $this->assertStringContainsString('Invalid phpdocs tag @inheritdoc', $result);
+        $this->assertStringNotContainsString('Incorrect path for phpdocs tag @covers', $result);
+        $this->assertStringNotContainsString('Incorrect path for phpdocs tag @dataProvider', $result);
+        $this->assertStringNotContainsString('Incorrect path for phpdocs tag @group', $result);
+        $this->assertStringNotContainsString('@deprecated', $result);
+        $this->assertStringNotContainsString('@codingStandardsIgnoreLine', $result);
     }
 
     /**
@@ -172,17 +172,17 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
                 '</file>');
         $this->assertEqualXMLStructure($expect->firstChild, $xmlresult->firstChild, true);
         // Also verify various bits by content.
-        $this->assertContains('packagevalid', $result);
-        $this->assertContains('Invalid inline phpdocs tag @param found', $result);
-        $this->assertContains('Invalid inline phpdocs tag @throws found', $result);
-        $this->assertContains('Inline phpdocs tag {@link tags have to be 1 url} with incorrect', $result);
-        $this->assertContains('Inline phpdocs tag {@see must be 1 word only} with incorrect', $result);
-        $this->assertContains('Inline phpdocs tag {@see $this-&gt;tagrules[&#039;url&#039;]} with incorrect', $result);
-        $this->assertContains('Inline phpdocs tag not enclosed with curly brackets @see found', $result);
-        $this->assertContains('It must match {@link valid URL} or {@see valid FQSEN}', $result);
-        $this->assertNotContains('{@link https://moodle.org}', $result);
-        $this->assertNotContains('{@see has_capability}', $result);
-        $this->assertNotContains('baby}', $result);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringContainsString('Invalid inline phpdocs tag @param found', $result);
+        $this->assertStringContainsString('Invalid inline phpdocs tag @throws found', $result);
+        $this->assertStringContainsString('Inline phpdocs tag {@link tags have to be 1 url} with incorrect', $result);
+        $this->assertStringContainsString('Inline phpdocs tag {@see must be 1 word only} with incorrect', $result);
+        $this->assertStringContainsString('Inline phpdocs tag {@see $this-&gt;tagrules[&#039;url&#039;]} with incorrect', $result);
+        $this->assertStringContainsString('Inline phpdocs tag not enclosed with curly brackets @see found', $result);
+        $this->assertStringContainsString('It must match {@link valid URL} or {@see valid FQSEN}', $result);
+        $this->assertStringNotContainsString('{@link https://moodle.org}', $result);
+        $this->assertStringNotContainsString('{@see has_capability}', $result);
+        $this->assertStringNotContainsString('baby}', $result);
     }
 
     /**
@@ -229,9 +229,9 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $result = $output->display_path($checkpath, 'xml');
 
         if ($expectclassesdocumentedfail) {
-            $this->assertContains('classesdocumented', $result);
+            $this->assertStringContainsString('classesdocumented', $result);
         } else {
-            $this->assertNotContains('classesdocumented', $result);
+            $this->assertStringNotContainsString('classesdocumented', $result);
         }
     }
 

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -182,7 +182,7 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertStringContainsString('It must match {@link valid URL} or {@see valid FQSEN}', $result);
         $this->assertStringNotContainsString('{@link https://moodle.org}', $result);
         $this->assertStringNotContainsString('{@see has_capability}', $result);
-        $this->assertStringNotContainsString('baby}', $result);
+        $this->assertStringNotContainsString('ba8by}', $result);
     }
 
     /**


### PR DESCRIPTION
Also
- Remove php70 tests because they don't support return :void
- Remove old versions using PHPUnit 6.x because they are missing the
  stringContainsString() assertion.
- Reorganize the travis files to avoid using exceptions and change
  to explicit positive alternative.