### PR TITLE
Add Github Actions to local_moodlecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,154 @@
+name: Moodlecheck CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 7.4
+            moodle-branch: master
+            database: pgsql
+          - php: 7.4
+            moodle-branch: master
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_311_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_311_STABLE
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_310_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_39_STABLE
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_38_STABLE
+            database: pgsql
+
+          - php: 7.3
+            moodle-branch: master
+            database: pgsql
+          - php: 7.3
+            moodle-branch: master
+            database: mariadb
+          - php: 7.3
+            moodle-branch: MOODLE_311_STABLE
+            database: pgsql
+          - php: 7.3
+            moodle-branch: MOODLE_311_STABLE
+            database: mariadb
+          - php: 7.3
+            moodle-branch: MOODLE_37_STABLE
+            database: pgsql
+
+          - php: 7.2
+            moodle-branch: MOODLE_310_STABLE
+            database: pgsql
+          - php: 7.2
+            moodle-branch: MOODLE_39_STABLE
+            database: mariadb
+
+          - php: 7.1
+            moodle-branch: MOODLE_38_STABLE
+            database: pgsql
+          - php: 7.1
+            moodle-branch: MOODLE_37_STABLE
+            database: mariadb
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: moodle/tests/fixtures,moodle/Sniffs
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ false }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,13 @@ before_install:
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+  - >
+    if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_TOKEN" ]; then
+        echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
+        echo "Using authenticated connection (no pull limits)"
+    else
+        echo "Using unauthenticated docker (pull limits may apply). Setup DOCKER_USER and DOCKER_TOKEN if needed."
+    fi
 
 install:
   - moodle-plugin-ci install
@@ -76,7 +83,7 @@ script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
-  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci codechecker --max-warnings 0
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache

--- a/file.php
+++ b/file.php
@@ -721,10 +721,13 @@ class local_moodlecheck_file {
                         // This is the doc comment to the following class/function.
                         $found = false;
                     }
-                    // } else {
                     // TODO: change to debugging.
-                    // echo "************ Unknown token following the first phpdocs in {$this->filepath}: id = {$nexttoken[0]}, text = '{$nexttoken[1]}' **************<br>".
-                    // }
+                    // } else {
+                    // echo "************ "
+                    // echo "Unknown token following the first phpdocs in "
+                    // echo "{$this->filepath}: id = {$nexttoken[0]}, text = '{$nexttoken[1]}'"
+                    // echo " **************<br>"
+                    // }.
                 }
             }
             $this->filephpdocs = $this->get_phpdocs($found);

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -24,7 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-local_moodlecheck_registry::add_rule('noemptysecondline')->set_callback('local_moodlecheck_noemptysecondline')->set_severity('warning');
+local_moodlecheck_registry::add_rule('noemptysecondline')->set_callback('local_moodlecheck_noemptysecondline')
+    ->set_severity('warning');
 local_moodlecheck_registry::add_rule('filephpdocpresent')->set_callback('local_moodlecheck_filephpdocpresent');
 local_moodlecheck_registry::add_rule('classesdocumented')->set_callback('local_moodlecheck_classesdocumented');
 local_moodlecheck_registry::add_rule('functionsdocumented')->set_callback('local_moodlecheck_functionsdocumented');
@@ -40,8 +41,10 @@ local_moodlecheck_registry::add_rule('definedoccorrect')->set_callback('local_mo
 local_moodlecheck_registry::add_rule('filehascopyright')->set_callback('local_moodlecheck_filehascopyright');
 local_moodlecheck_registry::add_rule('filehaslicense')->set_callback('local_moodlecheck_filehaslicense');
 local_moodlecheck_registry::add_rule('phpdocsinvalidtag')->set_callback('local_moodlecheck_phpdocsinvalidtag');
-local_moodlecheck_registry::add_rule('phpdocsnotrecommendedtag')->set_callback('local_moodlecheck_phpdocsnotrecommendedtag')->set_severity('warning');
-local_moodlecheck_registry::add_rule('phpdocsinvalidpathtag')->set_callback('local_moodlecheck_phpdocsinvalidpathtag')->set_severity('warning');
+local_moodlecheck_registry::add_rule('phpdocsnotrecommendedtag')->set_callback('local_moodlecheck_phpdocsnotrecommendedtag')
+    ->set_severity('warning');
+local_moodlecheck_registry::add_rule('phpdocsinvalidpathtag')->set_callback('local_moodlecheck_phpdocsinvalidpathtag')
+    ->set_severity('warning');
 local_moodlecheck_registry::add_rule('phpdocsinvalidinlinetag')->set_callback('local_moodlecheck_phpdocsinvalidinlinetag');
 local_moodlecheck_registry::add_rule('phpdocsuncurlyinlinetag')->set_callback('local_moodlecheck_phpdocsuncurlyinlinetag');
 local_moodlecheck_registry::add_rule('phpdoccontentsinlinetag')->set_callback('local_moodlecheck_phpdoccontentsinlinetag');
@@ -444,7 +447,9 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                 }
             }
             if (!$match) {
-                $errors[] = array('line' => $function->phpdocs->get_line_number($file, '@param'), 'function' => $function->fullname);
+                $errors[] = array(
+                    'line' => $function->phpdocs->get_line_number($file, '@param'),
+                    'function' => $function->fullname);
             }
         }
     }
@@ -463,7 +468,9 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
         if ($variable->phpdocs !== false) {
             $documentedvars = $variable->phpdocs->get_params('var', 2);
             if (!count($documentedvars) || $documentedvars[0][0] == 'type') {
-                $errors[] = array('line' => $variable->phpdocs->get_line_number($file, '@var'), 'variable' => $variable->fullname);
+                $errors[] = array(
+                    'line' => $variable->phpdocs->get_line_number($file, '@var'),
+                    'variable' => $variable->fullname);
             }
         }
     }
@@ -480,7 +487,8 @@ function local_moodlecheck_definedoccorrect(local_moodlecheck_file $file) {
     $errors = array();
     foreach ($file->get_defines() as $object) {
         if ($object->phpdocs !== false) {
-            if (!preg_match('/^\s*'.$object->name.'\s+-\s+(.*)/', $object->phpdocs->get_description(), $matches) || !strlen(trim($matches[1]))) {
+            if (!preg_match('/^\s*'.$object->name.'\s+-\s+(.*)/', $object->phpdocs->get_description(), $matches) ||
+                    !strlen(trim($matches[1]))) {
                 $errors[] = array('line' => $object->phpdocs->get_line_number($file), 'object' => $object->fullname);
             }
         }


### PR DESCRIPTION
Also, add the ability to travis runs to log-in to
DockerHub to avoid pulling rate limits.

With this patch, if both DOCKER_USER and DOCKER_TOKEN are defined
as environmental variables, they will be used to perform a login
to dockerhub, getting rid of pull limits.

Exactly the same than https://github.com/moodlehq/moodle-local_codechecker/pull/133
but applied to this repo.