### PR TITLE
Stop requiring the file phpdoc block for 1-artifact files

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -70,6 +70,11 @@ function local_moodlecheck_noemptysecondline(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_filephpdocpresent(local_moodlecheck_file $file) {
+    // This rule doesn't apply if the file is 1-artifact file (see #66).
+    $artifacts = $file->get_artifacts();
+    if (count($artifacts[T_CLASS]) + count($artifacts[T_INTERFACE]) + count($artifacts[T_TRAIT]) === 1) {
+        return array();
+    }
     if ($file->find_file_phpdocs() === false) {
         $tokens = &$file->get_tokens();
         for ($i = 0; $i < 30; $i++) {

--- a/tests/fixtures/phpdoc_file_required_no1.php
+++ b/tests/fixtures/phpdoc_file_required_no1.php
@@ -1,0 +1,24 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy class without any tags.
+ */
+class dummy_fileclass_without_tags {
+    // As far as this is an 1-artifact file, the file phpdoc block is not required.
+}

--- a/tests/fixtures/phpdoc_file_required_no2.php
+++ b/tests/fixtures/phpdoc_file_required_no2.php
@@ -1,0 +1,24 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy interface without any tags.
+ */
+interface dummy_fileinterface_without_tags {
+    // As far as this is an 1-artifact file, the file phpdoc block is not required.
+}

--- a/tests/fixtures/phpdoc_file_required_no3.php
+++ b/tests/fixtures/phpdoc_file_required_no3.php
@@ -1,0 +1,24 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy trait without any tags.
+ */
+trait dummy_filetrait_without_tags {
+    // As far as this is an 1-artifact file, the file phpdoc block is not required.
+}

--- a/tests/fixtures/phpdoc_file_required_yes1.php
+++ b/tests/fixtures/phpdoc_file_required_yes1.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy class without any tags.
+ */
+class dummy_fileclass1_without_tags {
+}
+
+/**
+ * This is another dummy class without any tags. Hence, file phpdoc block is required.
+ */
+class dummy2_fileclass2_without_tags {
+}

--- a/tests/fixtures/phpdoc_file_required_yes2.php
+++ b/tests/fixtures/phpdoc_file_required_yes2.php
@@ -1,0 +1,23 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+// This is library-style php file, no classes around.
+
+function dummy_filefunction_without_tags() {
+    // No classes, hence the file phpdoc block is required.
+}

--- a/tests/fixtures/phpdoc_file_required_yes3.php
+++ b/tests/fixtures/phpdoc_file_required_yes3.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * This is a dummy interface without any tags.
+ */
+interface dummy_fileinterface1_without_tags {
+}
+
+/**
+ * This is a dummy trait without any tags. Hence, file phpdoc block is required.
+ */
+trait dummy_filetrait1_without_tags {
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -76,6 +76,45 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
     }
 
     /**
+     * Assert that the file block is required for old files, and not for 1-artifact ones.
+     */
+    public function test_file_block_required() {
+        global $PAGE;
+
+        $output = $PAGE->get_renderer('local_moodlecheck');
+
+        // A file with multiple classes, require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_yes1.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringContainsString('File-level phpdocs block is not found', $result);
+
+        // A file without any class (library-like), require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_yes2.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringContainsString('File-level phpdocs block is not found', $result);
+
+        // A file with one interface and one trait, require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_yes3.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringContainsString('File-level phpdocs block is not found', $result);
+
+        // A file with only one class, do not require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_no1.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringNotContainsString('File-level phpdocs block is not found', $result);
+
+        // A file with only one interface, do not require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_no2.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringNotContainsString('File-level phpdocs block is not found', $result);
+
+        // A file with only one trait, do not require the file phpdoc block.
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_file_required_no3.php', null);
+        $result = $output->display_path($path, 'xml');
+        $this->assertStringNotContainsString('File-level phpdocs block is not found', $result);
+    }
+
+    /**
      * Assert that classes do not need to have any particular phpdocs tags.
      */
     public function test_classtags() {


### PR DESCRIPTION
Now we detect all the classes, interfaces and traits in a file
and, if there is only one, then we stop requiring the file
phpdoc block.

This was agreed @ https://tracker.moodle.org/browse/MDLSITE-2804
and https://github.com/moodlehq/moodle-local_moodlecheck/issues/66
was created to implement it.

Note this doesn't address the whole agreement, but just the
detail about stop requiring the file phpdoc block, because it
is specially annoying and recurring in new files (that use to
be 1-artifact ones).