### PR TITLE
Add support for variadic function and add more tests.

### DIFF
--- a/file.php
+++ b/file.php
@@ -310,12 +310,17 @@ class local_moodlecheck_file {
                     foreach ($function->argumentstokens as $argtokens) {
                         $type = null;
                         $variable = null;
+                        $splat = false;
                         for ($j = 0; $j < count($argtokens); $j++) {
                             if ($argtokens[$j][0] == T_VARIABLE) {
-                                $variable = $argtokens[$j][1];
+                                $variable = ($splat) ? '...'.$argtokens[$j][1] : $argtokens[$j][1];
                                 break;
-                            } else if ($argtokens[$j][0] != T_WHITESPACE && $argtokens[$j][1] != '&') {
+                            } else if ($argtokens[$j][0] != T_WHITESPACE &&
+                                    $argtokens[$j][0] != T_ELLIPSIS && $argtokens[$j][1] != '&') {
                                 $type = $argtokens[$j][1];
+                            } else if ($argtokens[$j][0] == T_ELLIPSIS) {
+                                // Variadic function.
+                                $splat = true;
                             }
                         }
                         $function->arguments[] = array($type, $variable);

--- a/tests/fixtures/phpdoc_tags_general.php
+++ b/tests/fixtures/phpdoc_tags_general.php
@@ -62,4 +62,172 @@ class fixturing_general {
     public function all_invalid_tags() {
         echo "yoy!";
     }
+
+    /**
+     * Incomplete param annotation (type is missing).
+     *
+     * @param $one
+     * @param $two
+     */
+    public function incomplete_param_annotation($one, $two) {
+        echo "yoy!";
+    }
+
+    /**
+     * Missing param definition.
+     *
+     * @param string $one
+     * @param bool $two
+     */
+    public function missing_param_defintion() {
+        echo "yoy!";
+    }
+
+    /**
+     * Missing param annotation.
+     */
+    public function missing_param_annotation(string $one, bool $two) {
+        echo "yoy!";
+    }
+
+    /**
+     * Incomplete param definition.
+     *
+     * @param string $one
+     * @param bool $two
+     */
+    public function incomplete_param_definition(string $one) {
+        echo "yoy!";
+    }
+
+    /**
+     * Incomplete param annotation (annotation is missing).
+     *
+     * @param string $one
+     */
+    public function incomplete_param_annotation1(string $one, bool $two) {
+        echo "yoy!";
+    }
+
+    /**
+     * Mismatch param types.
+     *
+     * @param string $one
+     * @param bool $two
+     */
+    public function mismatch_param_types(string $one, array $two = []) {
+        echo "yoy!";
+    }
+
+    /**
+     * Mismatch param types.
+     *
+     * @param string|bool $one
+     * @param bool $two
+     */
+    public function mismatch_param_types1(string $one, bool $two) {
+        echo "yoy!";
+    }
+
+    /**
+     * Mismatch param types.
+     *
+     * @param string|bool $one
+     * @param bool $params
+     */
+    public function mismatch_param_types2(string $one, ...$params) {
+        echo "yoy!";
+    }
+
+    /**
+     * Mismatch param types.
+     *
+     * @param string $one
+     * @param int[] $params
+     */
+    public function mismatch_param_types3(string $one, int $params) {
+        echo "yoy!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string|bool $one
+     * @param bool $two
+     * @param array $three
+     */
+    public function correct_param_types($one, bool $two, array $three) {
+        echo "yay!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string|bool $one
+     * @param bool $two
+     * @param array $three
+     */
+    public function correct_param_types1($one, bool $two, array $three) {
+        echo "yay!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string $one
+     * @param bool $two
+     */
+    public function correct_param_types2($one, $two) {
+        echo "yay!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string|null $one
+     * @param bool $two
+     * @param array $three
+     */
+    public function correct_param_types3(?string $one = null, bool $two, array $three) {
+        echo "yay!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string|null $one
+     * @param bool $two
+     * @param int[] $three
+     */
+    public function correct_param_types4($one = null, bool $two, array $three) {
+        echo "yay!";
+    }
+
+    /**
+     * Correct param types.
+     *
+     * @param string $one
+     * @param mixed ...$params one or more params
+     */
+    public function correct_param_types5(string $one, ...$params) {
+        echo "yay!";
+    }
+
+    /**
+     * Incomplete return annotation (type is missing).
+     *
+     * @return
+     */
+    public function incomplete_return_annotation() {
+        echo "yoy!";
+    }
+
+    /**
+     * Correct return type.
+     *
+     * @return string
+     */
+    public function correct_return_type(): string {
+        return "yay!";
+    }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -146,10 +146,20 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $xpath = new DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(8, $found->length);
+        $this->assertSame(18, $found->length);
 
         // Also verify various bits by content.
         $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringContainsString('incomplete_param_annotation has incomplete parameters list', $result);
+        $this->assertStringContainsString('missing_param_defintion has incomplete parameters list', $result);
+        $this->assertStringContainsString('missing_param_annotation has incomplete parameters list', $result);
+        $this->assertStringContainsString('incomplete_param_definition has incomplete parameters list', $result);
+        $this->assertStringContainsString('incomplete_param_annotation1 has incomplete parameters list', $result);
+        $this->assertStringContainsString('mismatch_param_types has incomplete parameters list', $result);
+        $this->assertStringContainsString('mismatch_param_types1 has incomplete parameters list', $result);
+        $this->assertStringContainsString('mismatch_param_types2 has incomplete parameters list', $result);
+        $this->assertStringContainsString('mismatch_param_types3 has incomplete parameters list', $result);
+        $this->assertStringContainsString('incomplete_return_annotation has incomplete parameters list', $result);
         $this->assertStringContainsString('Invalid phpdocs tag @small', $result);
         $this->assertStringContainsString('Invalid phpdocs tag @zzzing', $result);
         $this->assertStringContainsString('Invalid phpdocs tag @inheritdoc', $result);
@@ -158,6 +168,8 @@ class local_moodlecheck_rules_testcase extends advanced_testcase {
         $this->assertStringContainsString('Incorrect path for phpdocs tag @group', $result);
         $this->assertStringNotContainsString('@deprecated', $result);
         $this->assertStringNotContainsString('@codingStandardsIgnoreLine', $result);
+        $this->assertStringNotContainsString('correct_param_types', $result);
+        $this->assertStringNotContainsString('correct_return_type', $result);
     }
 
     /**


### PR DESCRIPTION
This patch adds support for variadic function (aka splat) and expands test.

Suggested phpdoc annotation to support:

`@param <type> ...$args`

this is in line with known tools ([more info](https://github.com/20Tauri/DoxyDoxygen/issues/135#issuecomment-512090231)).

Fixes #42