### PR TITLE
Ensure that only the final part of namespaces is returned

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,9 +26,6 @@ namespace local_moodlecheck\privacy;
 
 defined('MOODLE_INTERNAL') || die();
 
-use core_privacy\local\legacy_polyfill;
-use core_privacy\local\metadata\null_provider;
-
 /**
  * Privacy provider for local_moodlecheck implementing null provider
  *
@@ -36,9 +33,7 @@ use core_privacy\local\metadata\null_provider;
  * @copyright   2019 Paul Holden <paulh@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class provider implements null_provider {
-
-    use legacy_polyfill;
+class provider implements \core_privacy\local\metadata\null_provider {
 
     /**
      * Get the language string identifier with the component's language
@@ -46,7 +41,7 @@ class provider implements null_provider {
      *
      * @return string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/file.php
+++ b/file.php
@@ -323,6 +323,17 @@ class local_moodlecheck_file {
                                 $splat = true;
                             }
                         }
+
+                        // PHP 8 treats namespaces as single token. So we are going to undo this here
+                        // and continue returning only the final part of the namespace. Someday we'll
+                        // move to use full namespaces here, but not for now (we are doing the same,
+                        // in other parts of the code, when processing phpdoc blocks).
+                        if (strpos($type, '\\') !== false) {
+                            // Namespaced typehint, potentially sub-namespaced.
+                            // We need to strip namespacing as this area just isn't that smart.
+                            $type = substr($type, strrpos($type, '\\') + 1);
+                        }
+
                         $function->arguments[] = array($type, $variable);
                     }
                     $function->boundaries = $this->find_object_boundaries($function);


### PR DESCRIPTION
This tool has limited namespace handling capabilities and
we always have been getting, exclusively, the last part of
every namespace detected in function params.

This was the default behavior for PHP7 tokenizer and, in fact,
when reading the phpdocs for those params... we are removing
everything but the final part of the namespace too.

But PHP8 changed the default behavior and its tokenizer now
returns the complete namespace as unique token.

https://wiki.php.net/rfc/namespaced_names_as_token

So, to keep everything working as it was... when we detect that
some type of the function params contains namespaces, we are also
going to remove everything but the final part of the namespace.

That matches previous behaviour 100%.

If some day we want to go processing full namespaces (instead of
their final parts), that will be great, but not now.

Fixes #72.