### PR TITLE
Perform some php8 runs with 311 and master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 7.4
+          - php: 8.0
             moodle-branch: master
             database: pgsql
-          - php: 7.4
+          # The following line is only needed if you're going to run php8 jobs and your
+          # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: master
             database: mariadb
-          - php: 7.4
+          # The following line is only needed if you're going to run php8 jobs and your
+          # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: MOODLE_311_STABLE
             database: pgsql
-          - php: 7.4
+          # The following line is only needed if you're going to run php8 jobs and your
+          # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: MOODLE_311_STABLE
             database: mariadb
+          # The following line is only needed if you're going to run php8 jobs and your
+          # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+
           - php: 7.4
             moodle-branch: MOODLE_310_STABLE
             database: pgsql
@@ -89,6 +102,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
           coverage: none
 
       - name: Initialise moodle-plugin-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ cache:
 
 jobs:
   include:
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=master            DB=pgsql
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=master            DB=mysqli
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
@@ -64,6 +64,10 @@ jobs:
     # be executed with that PHP versions.
 
 before_install:
+  # The following line is only needed if you're going to run php8 jobs and your
+  # plugin needs xmlrpc services.
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
+  - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2019101700;
-$plugin->requires = 2010112400;
+$plugin->version  = 2021051200;
+$plugin->requires = 2018051700;
 $plugin->component = 'local_moodlecheck';


### PR DESCRIPTION
Note that this is build on top of #73 and only can be merged after it!


Only real required change  is to set the new
max_input_vars=5000 requirement. Strictly speaking
only needed for php8, but it doesn't hurt with
older php versions and older moodle branches, so
setting it up always.

About the xmlrpc-beta extension, it's only needed
for php8 runs and only if the plugin uses xmlrpc
for something. Else, it can be omitted without
problem, as far as it's not a moodle requirement
but only a recommendation.

Finally, also bump version.php to current date
and make Moodle 3.5 (2018051700) required. This is
to make a new release in the plugins database.