### PR TITLE
Allow support for description when checking inline @link/@see tags

### DIFF
--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -75,7 +75,7 @@ $string['rule_phpdocsinvalidinlinetag'] = 'Inline phpdocs tags are valid';
 $string['error_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tag not enclosed with curly brackets <b>{$a->tag}</b> found';
 $string['rule_phpdocsuncurlyinlinetag'] = 'Inline phpdocs tags are enclosed with curly brackets';
 
-$string['error_phpdoccontentsinlinetag'] = 'Inline phpdocs tag <b>{$a->tag}</b> with incorrect contents found. It must match {@link valid URL} or {@see valid FQSEN}';
+$string['error_phpdoccontentsinlinetag'] = 'Inline phpdocs tag <b>{$a->tag}</b> with incorrect contents found. It must match {@link [valid URL] [description (optional)]} or {@see [valid FQSEN] [description (optional)]}';
 $string['rule_phpdoccontentsinlinetag'] = 'Inline phpdocs tags have correct contents';
 
 $string['error_functiondescription'] = 'There is no description in phpdocs for function <b>{$a->object}</b>';

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -317,6 +317,8 @@ function local_moodlecheck_phpdocsuncurlyinlinetag(local_moodlecheck_file $file)
 /**
  * Check that all the valid inline curly tags have correct contents.
  *
+ * @link https://docs.phpdoc.org/3.0/guide/references/phpdoc/inline-tags/link.html#link phpDocumentor@link
+ * @link https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/see.html#see          phpDocumentor@see
  * @param local_moodlecheck_file $file
  * @return array of found errors
  */
@@ -325,19 +327,20 @@ function local_moodlecheck_phpdoccontentsinlinetag(local_moodlecheck_file $file)
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         if ($curlyinlinetags = $phpdocs->get_inline_tags(true, true)) {
             foreach ($curlyinlinetags as $curlyinlinetag) {
-                // Split into tag and content.
-                list($tag, $content) = explode(' ', $curlyinlinetag, 2);
+                // Split into tag and URL/FQSEN. Limit of 3 because the 3rd part can be the description.
+                list($tag, $uriorfqsen) = explode(' ', $curlyinlinetag, 3);
                 if (in_array($tag, local_moodlecheck_phpdocs::$inlinetags)) {
                     switch ($tag) {
-                        case 'link': // Must be a correct URL.
-                            if (!filter_var($content, FILTER_VALIDATE_URL)) {
+                        case 'link':
+                            // Must be a correct URL with optional description.
+                            if (!filter_var($uriorfqsen, FILTER_VALIDATE_URL)) {
                                 $errors[] = array(
                                     'line' => $phpdocs->get_line_number($file, ' {@' . $curlyinlinetag),
                                     'tag' => '{@' . $curlyinlinetag . '}');
                             }
                             break;
                         case 'see': // Must be 1-word (with some chars allowed - FQSEN only.
-                            if (str_word_count($content, 0, '\()-_:>$012345789') !== 1) {
+                            if (str_word_count($uriorfqsen, 0, '\()-_:>$012345789') !== 1) {
                                 $errors[] = array(
                                     'line' => $phpdocs->get_line_number($file, ' {@' . $curlyinlinetag),
                                     'tag' => '{@' . $curlyinlinetag . '}');

--- a/tests/fixtures/phpdoc_tags_inline.php
+++ b/tests/fixtures/phpdoc_tags_inline.php
@@ -57,6 +57,8 @@ class fixturing_inline {
      *
      * To know more, visit {@link https://moodle.org} for Moodle info.
      * To know more, take a look to {@see has_capability} about permissions.
+     * {@link https://moodle.org Links tags with descriptions} should be fine as long as they contain valid URL.
+     * {@see some_function See tags with descriptions} should be fine as well.
      * And verify that crazy {@see \so-me\com-plex\th_ing::$come->ba8by()} are ok too.
      */
     public function correct_inline_tags() {
@@ -68,8 +70,8 @@ class fixturing_inline {
      *
      * This tag {@param string Some param} cannot be used inline.
      * Neither {@throws exception} can.
-     * Ideally all {@link tags have to be 1 url}.
-     * And all {@see must be 1 word only}
+     * Ideally all {@link tags need to have a valid URL}. An optional description is allowed too.
+     * {@see https://moodle.org We do not support URLs in see tags.} See MDLSITE-6105.
      * And {@see $this->tagrules['url']} is not a proper structural element.
      * Also they aren't valid without using @see curly brackets
      */

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -259,11 +259,13 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $this->assertStringContainsString('packagevalid', $result);
         $this->assertStringContainsString('Invalid inline phpdocs tag @param found', $result);
         $this->assertStringContainsString('Invalid inline phpdocs tag @throws found', $result);
-        $this->assertStringContainsString('Inline phpdocs tag {@link tags have to be 1 url} with incorrect', $result);
-        $this->assertStringContainsString('Inline phpdocs tag {@see must be 1 word only} with incorrect', $result);
+        $this->assertStringContainsString('Inline phpdocs tag {@link tags need to have a valid URL} with incorrect', $result);
         $this->assertStringContainsString('Inline phpdocs tag {@see $this-&gt;tagrules[&#039;url&#039;]} with incorrect', $result);
         $this->assertStringContainsString('Inline phpdocs tag not enclosed with curly brackets @see found', $result);
-        $this->assertStringContainsString('It must match {@link valid URL} or {@see valid FQSEN}', $result);
+        $this->assertStringContainsString(
+            'It must match {@link [valid URL] [description (optional)]} or {@see [valid FQSEN] [description (optional)]}',
+            $result
+        );
         $this->assertStringNotContainsString('{@link https://moodle.org}', $result);
         $this->assertStringNotContainsString('{@see has_capability}', $result);
         $this->assertStringNotContainsString('ba8by}', $result);


### PR DESCRIPTION
Optional descriptions are allowed in inline @link and @see tags. I think it would be good to support this.

For more info, check out:
https://docs.phpdoc.org/3.0/guide/references/phpdoc/inline-tags/