### PR TITLE
Bump GHA environments to use Ubuntu 22.04 (up from 18.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:

--- a/locallib.php
+++ b/locallib.php
@@ -176,7 +176,7 @@ class local_moodlecheck_path {
         $path = clean_param(trim($path), PARAM_PATH);
         // If the path is already one existing full path
         // accept it, else assume it's a relative one.
-        if (!file_exists($path) and substr($path, 0, 1) == '/') {
+        if (!file_exists($path) && substr($path, 0, 1) == '/') {
             $path = substr($path, 1);
         }
         $this->path = $path;
@@ -262,7 +262,7 @@ class local_moodlecheck_path {
         if (empty($componentsfile)) {
             return array();
         }
-        if (file_exists($componentsfile) and is_readable($componentsfile)) {
+        if (file_exists($componentsfile) && is_readable($componentsfile)) {
             $fh = fopen($componentsfile, 'r');
             while (($line = fgets($fh, 4096)) !== false) {
                 $split = explode(',', $line);
@@ -270,7 +270,7 @@ class local_moodlecheck_path {
                     // Wrong count of elements in the line.
                     continue;
                 }
-                if (trim($split[0]) != 'plugin' and trim($split[0]) != 'subsystem') {
+                if (trim($split[0]) != 'plugin' && trim($split[0]) != 'subsystem') {
                     // Wrong type.
                     continue;
                 }

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -117,8 +117,8 @@ function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs === false) {
             // Exception is made for plain phpunit test methods MDLSITE-3282, MDLSITE-3856.
-            $istestmethod = (strpos($function->name, 'test_') === 0 or
-                            stripos($function->name, 'setup') === 0 or
+            $istestmethod = (strpos($function->name, 'test_') === 0 ||
+                            stripos($function->name, 'setup') === 0 ||
                             stripos($function->name, 'teardown') === 0);
             if (!($isphpunitfile && $istestmethod)) {
                 $errors[] = array('function' => $function->fullname, 'line' => $file->get_line_number($function->boundaries[0]));
@@ -224,7 +224,7 @@ function local_moodlecheck_phpdocsnotrecommendedtag(local_moodlecheck_file $file
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         foreach ($phpdocs->get_tags() as $tag) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
-            if (in_array($tag, local_moodlecheck_phpdocs::$validtags) and
+            if (in_array($tag, local_moodlecheck_phpdocs::$validtags) &&
                     !in_array($tag, local_moodlecheck_phpdocs::$recommendedtags)) {
                 $errors[] = array(
                     'line' => $phpdocs->get_line_number($file, '@' . $tag),
@@ -246,8 +246,8 @@ function local_moodlecheck_phpdocsinvalidpathtag(local_moodlecheck_file $file) {
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         foreach ($phpdocs->get_tags() as $tag) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
-            if (in_array($tag, local_moodlecheck_phpdocs::$validtags) and
-                    in_array($tag, local_moodlecheck_phpdocs::$recommendedtags) and
+            if (in_array($tag, local_moodlecheck_phpdocs::$validtags) &&
+                    in_array($tag, local_moodlecheck_phpdocs::$recommendedtags) &&
                     isset(local_moodlecheck_phpdocs::$pathrestrictedtags[$tag])) {
                 // Verify file path matches some of the valid paths for the tag.
                 if (!preg_filter(local_moodlecheck_phpdocs::$pathrestrictedtags[$tag], '$0', $file->get_filepath())) {

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -133,7 +133,7 @@ function local_moodlecheck_package_names(local_moodlecheck_file $file) {
         // Prepare the list of core packages.
         foreach ($allsubsystems as $subsystem => $dir) {
             // Subsytems may come with the valid component name (core_ prefixed) already.
-            if (strpos($subsystem, 'core_') === 0 or $subsystem === 'core') {
+            if (strpos($subsystem, 'core_') === 0 || $subsystem === 'core') {
                 $corepackages[] = $subsystem;
             } else {
                 $corepackages[] = 'core_' . $subsystem;


### PR DESCRIPTION
Since some time ago, GH is warning us that the Ubuntu 18.04 environment is deprecated:

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead...."

Hence, we are bumping here, to be able to cerify if everything continues working ok