### PR TITLE
#82: Make undocumented methods in subclasses warnings

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -102,7 +102,7 @@ class local_moodlecheck_rule {
         foreach ($reterrors as $args) {
             $ruleerrors[] = array(
                 'line' => $args['line'],
-                'severity' => $this->severity,
+                'severity' => $args["severity"] ?? $this->severity,
                 'message' => $this->get_error_message($args),
                 'source' => $this->code
             );

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -105,14 +105,16 @@ function local_moodlecheck_classesdocumented(local_moodlecheck_file $file) {
 }
 
 /**
- * Checks if all functions have phpdocs blocks
+ * Checks if all functions have phpdocs blocks.
+ *
+ * For methods of a class which extends another or implements interfaces, a violation in only a warning, since the
+ * method might be overriding a sufficiently documented method. In all other cases, it is an error.
  *
  * @param local_moodlecheck_file $file
  * @return array of found errors
  */
 function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
-
-    $isphpunitfile = preg_match('#/tests/[^/]+_test\.php$#', $file->get_filepath());
+    $isphpunitfile = preg_match('#/tests/.+_test\.php$#', $file->get_filepath());
     $errors = array();
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs === false) {
@@ -120,8 +122,20 @@ function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
             $istestmethod = (strpos($function->name, 'test_') === 0 or
                             stripos($function->name, 'setup') === 0 or
                             stripos($function->name, 'teardown') === 0);
+
+            $isinsubclass = $function->class && ($function->class->hasextends || $function->class->hasimplements);
+
             if (!($isphpunitfile && $istestmethod)) {
-                $errors[] = array('function' => $function->fullname, 'line' => $file->get_line_number($function->boundaries[0]));
+                $error = [
+                    'function' => $function->fullname,
+                    'line' => $file->get_line_number($function->boundaries[0])
+                ];
+
+                if ($isinsubclass) {
+                    $error["severity"] = "warning";
+                }
+
+                $errors[] = $error;
             }
         }
     }

--- a/tests/fixtures/phpdoc_method_overrides.php
+++ b/tests/fixtures/phpdoc_method_overrides.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+interface dummy_top_level {
+    // Should be an error.
+    public function undocumented();
+}
+
+class dummy_implements_something implements dummy_top_level {
+    // Should be a warning.
+    public function undocumented() {}
+}
+
+class dummy_extends_something extends dummy_implements_something {
+    // Should be a warning.
+    public function undocumented() {}
+}
+
+class dummy_extends_and_implements_something extends dummy_implements_something implements dummy_top_level {
+    // Should be a warning.
+    public function undocumented() {}
+}


### PR DESCRIPTION
To make this possible, rule functions can now return a severity which will override the rule severity. `local_moodlecheck_functionsdocumented` returns `warning` if the artifact contains an `extends` or `implements` clause. Otherwise, it returns no severity, so the default `error` is used.

The existence of `extends` and `implements` clauses is determined solely by the existence of the keywords between `class` and `{`. I originally wrote some code to extract the superclass and interface names, but settled on this solution for simplicity.

I also changed the `$isphpunitfile` to also match test files in subdirectories. The previous pattern required test files to be directly below a `tests/` dir, which I believed to be a mistake.

Fixes #82