### PR TITLE
#81: Correctly detect PHPdoc on PHP 7.4 typed properties

### DIFF
--- a/tests/fixtures/phpdoc_properties.php
+++ b/tests/fixtures/phpdoc_properties.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A dummy class for tests of rules involving properties.
+ */
+class dummy_with_properties {
+    var $undocumented1;
+    var ?string $undocumented2;
+    private $undocumented3;
+    private ?string $undocumented4;
+
+    /**
+     * @var mixed $documented1 I'm just a dummy!
+     */
+    var $documented1;
+    /**
+     * @var mixed $documented2 I'm just a dummy!
+     */
+    var ?string $documented2;
+    /**
+     * @var mixed $documented3 I'm just a dummy!
+     */
+    private $documented3;
+    /**
+     * @var ?string $documented4 I'm just a dummy!
+     */
+    private ?string $documented4;
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -428,4 +428,35 @@ class moodlecheck_rules_test extends \advanced_testcase {
 
         $this->assertEquals(["error", "warning", "warning", "warning"], $severities);
     }
+
+    /**
+     * Verify that `variablesdocumented` correctly detects PHPdoc on different kinds of properties.
+     *
+     * @covers ::local_moodlecheck_variablesdocumented
+     * @covers \local_moodlecheck_file::get_variables
+     */
+    public function test_variablesdocumented() {
+        $file = __DIR__ . "/fixtures/phpdoc_properties.php";
+
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path($file, null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Object.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        $xpath = new \DOMXpath($xmlresult);
+
+        $found = $xpath->query('//file/error[@source="variablesdocumented"]');
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(4, $found->length);
+
+        // The PHPdocs of the other properties should be detected correctly.
+        $this->assertStringContainsString('$undocumented1', $found->item(0)->getAttribute("message"));
+        $this->assertStringContainsString('$undocumented2', $found->item(1)->getAttribute("message"));
+        $this->assertStringContainsString('$undocumented3', $found->item(2)->getAttribute("message"));
+        $this->assertStringContainsString('$undocumented4', $found->item(3)->getAttribute("message"));
+    }
 }


### PR DESCRIPTION
This implementation assumes that anything between modifier and property name is part of the property type and skips it before looking for the modifiers and PHPdoc. Judging by [the PHP yacc grammar](https://github.com/php/php-src/blob/c398694e19a7ad8b1e6c2f0fa9b489d405aa0219/Zend/zend_language_parser.y#L933), this should be correct.

Fixes #81