### PR TITLE
Allow the form to reload, for easier re-executions

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -315,7 +315,7 @@ class local_moodlecheck_form extends moodleform {
         $mform->addGroup($group, 'checkboxgroup', '', array('<br>'), false);
         foreach (local_moodlecheck_registry::get_registered_rules() as $code => $rule) {
             $group[] =& $mform->createElement('checkbox', "rule[$code]", ' ', $rule->get_name());
-            $mform->setDefault("rule[$code]", 1);
+            $mform->setDefault("rule[$code]", 0);
             $mform->disabledIf("rule[$code]", 'checkall', 'eq', 'all');
         }
 


### PR DESCRIPTION
Right now it's not possible to reload (F5) the moodlecheck page in order to re-execute the checks automatically.

That's a feature that the sister page @ codechecker has, and it's a facility to progressively got fixing and re-executing the same configured checks.

Basically implies to read all the params and perform a redirect so all the information is in the URL, available for re-execution.

No change in results or cli are expected, just the web/UI moodlecheck page can now be reloaded (in practice), that also implies that it's possible to invoke it from other places via properly escaped URL, for example:

site://local/moodlecheck/?path=mod%2Fforum

Fixes #88