### PR TITLE
#96: Support interfaces and traits in packagespecified and functionsdocumented

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -123,7 +123,7 @@ function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
                             stripos($function->name, 'setup') === 0 ||
                             stripos($function->name, 'teardown') === 0);
 
-            $isinsubclass = $function->class && ($function->class->hasextends || $function->class->hasimplements);
+            $isinsubclass = $function->owner && ($function->owner->hasextends || $function->owner->hasimplements);
 
             if (!($isphpunitfile && $istestmethod)) {
                 $error = [

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -41,19 +41,25 @@ function local_moodlecheck_packagespecified(local_moodlecheck_file $file) {
     $phpdocs = $file->find_file_phpdocs();
     if ($phpdocs && count($phpdocs->get_tags('package', true))) {
         // Package is specified on file level, it is automatically inherited.
-        return array();
+        return [];
     }
-    foreach ($file->get_classes() as $object) {
-        if (!$object->phpdocs || !count($object->phpdocs->get_tags('package', true))) {
-            $errors[] = array('line' => $file->get_line_number($object->boundaries[0]),
-                    'object' => 'class '. $object->name);
+
+    foreach ($file->get_artifacts_flat() as $artifact) {
+        if (!$artifact->phpdocs || !count($artifact->phpdocs->get_tags('package', true))) {
+            $errors[] = [
+                'line' => $file->get_line_number($artifact->boundaries[0]),
+                'object' => "$artifact->typestring $artifact->name",
+            ];
         }
     }
+
     foreach ($file->get_functions() as $object) {
-        if ($object->class === false) {
+        if ($object->owner === false) {
             if (!$object->phpdocs || !count($object->phpdocs->get_tags('package', true))) {
-                $errors[] = array('line' => $file->get_line_number($object->boundaries[0]),
-                        'object' => 'function '. $object->fullname);
+                $errors[] = [
+                    'line' => $file->get_line_number($object->boundaries[0]),
+                    'object' => 'function ' . $object->fullname,
+                ];
             }
         }
     }

--- a/tests/fixtures/phpdoc_tags_packagespecified.php
+++ b/tests/fixtures/phpdoc_tags_packagespecified.php
@@ -1,0 +1,118 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * A minimalistic file phpdoc block without package tag.
+ *
+ * @copyright 2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// These are missing any package tag.
+
+/**
+ * This is a class without package tag.
+ */
+class missingclass {
+    /**
+     * This is a method.
+     */
+    public function somemethod() {
+        return;
+    }
+}
+
+/**
+ * This is a trait without package tag.
+ */
+trait missingtrait {
+    /**
+     * This is a method.
+     */
+    public function somemethod() {
+        return;
+    }
+}
+
+/**
+ * This is an interface without package tag.
+ */
+interface missinginterface {
+    /**
+     * This is a method.
+     */
+    public function somemethod();
+}
+
+/**
+ * This is a global scope function without package tag.
+ */
+function missingfunction() {
+    return;
+}
+
+// These have parent package tag.
+
+/**
+ * Lovely class with package tag.
+ *
+ * @package local_moodlecheck
+ */
+class packagedclass {
+    /**
+     * This is a method.
+     */
+    public function somemethod() {
+        return;
+    }
+}
+
+/**
+ * Lovely trait with package tag.
+ *
+ * @package local_moodlecheck
+ */
+trait packagedtrait {
+    /**
+     * This is a method
+     */
+    public function somemethod() {
+        return;
+    }
+}
+
+/**
+ * Lovely interface with package tag.
+ *
+ * @package local_moodlecheck
+ */
+interface packagedinterface {
+    /**
+     * This is a method
+     */
+    public function somemethod();
+}
+
+/**
+ * Lovely global scope function with package tag.
+ *
+ * @package local_moodlecheck
+ */
+function packagedfunction() {
+    return;
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -272,6 +272,36 @@ class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify the package tag is required for class/trait/interface/global scope functions.
+     *
+     * @covers ::local_moodlecheck_packagespecified
+     */
+    public function test_phpdoc_tags_packagespecified() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_tags_packagespecified.php', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Object.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 4 children.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query('//file/error[@source="packagespecified"]');
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(4, $found->length);
+
+        // Also verify various bits by content.
+        $this->assertStringContainsString('Package is not specified for class missingclass', $result);
+        $this->assertStringContainsString('Package is not specified for interface missinginterface', $result);
+        $this->assertStringContainsString('Package is not specified for trait missingtrait', $result);
+        $this->assertStringContainsString('Package is not specified for function missingfunction', $result);
+        $this->assertStringNotContainsString('packaged', $result);
+        $this->assertStringNotContainsString('somemethod', $result);
+    }
+
+    /**
      * Test that {@see local_moodlecheck_get_categories()} returns the correct list of allowed categories.
      *
      * @covers ::local_moodlecheck_get_categories


### PR DESCRIPTION
Previously, only the class containing a function was retrieved and used in either rule. Now, the containing artifact is also looked up if it is an interface or a trait. Function objects contain a new `owner` property for this. I haven't removed the `class` property yet because I wasn't sure if there's some third-party code that could depend on it.

To include the correct artifact type (`class`, `interface`, or `trait`) in warnings, artifacts additional gain the property `typestring` containing one of those three strings.

Fixes #96