### PR TITLE
Bump to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             database: mariadb
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 


### PR DESCRIPTION
Related to this deprecation of NodeJS 12 for GHA actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

While it doesn't affect to this repository, let's bump to the new v3 version now so we keep it updated.