### PR TITLE
Allow trailing comma in method parameters to work ok

### DIFF
--- a/file.php
+++ b/file.php
@@ -357,6 +357,11 @@ class local_moodlecheck_file {
                     }
                     $function->arguments = array();
                     foreach ($function->argumentstokens as $argtokens) {
+                        // If the token is completely empty then it's not an argument. This happens, for example, with
+                        // trailing commas in parameters, allowed since PHP 8.0 and break_tokens_by() returns it that way.
+                        if (empty($argtokens)) {
+                            continue;
+                        }
                         $type = null;
                         $variable = null;
                         $splat = false;

--- a/tests/fixtures/phpdoc_method_multiline.php
+++ b/tests/fixtures/phpdoc_method_multiline.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class to verify that "multiline" method declarations are working ok.
+ *
+ * @package local_moodlecheck
+ */
+class something {
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_oneline(string $plugin, int $direction): array {
+        // Do something.
+    }
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_multiline1(string $plugin,
+            int $direction): array {
+        // Do something.
+    }
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_multiline2(string $plugin, int $direction)
+    : array {
+        // Do something.
+    }
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_multiline3(
+            string $plugin,
+            int $direction): array {
+        // Do something.
+    }
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_multiline4(
+        string $plugin,
+        int $direction
+    ): array {
+        // Do something.
+    }
+
+    /**
+     * One function, what else.
+     *
+     * @param string $plugin A plugin name.
+     * @param int $direction A direction.
+     * @return array
+     */
+    public function function_multiline5(
+        string $plugin,
+        int $direction,
+    ): array {
+        // Do something.
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -431,6 +431,30 @@ class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify that method parameters are correctly interpreted no matter the definition style.
+     *
+     * @covers ::local_moodlecheck_functionarguments
+     */
+    public function test_functionsdocumented_method_multiline() {
+        $file = __DIR__ . "/fixtures/phpdoc_method_multiline.php";
+
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path($file, null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Object.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query('//file/error[@source="functionarguments"]');
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(0, $found->length); // All examples in fixtures are ok.
+    }
+
+
+    /**
      * Verify that top-level methods without docs are errors but methods in subclasses without docs are warnings.
      *
      * @covers ::local_moodlecheck_functionsdocumented


### PR DESCRIPTION
Since PHP 8.0, trailing commas in method parameters are allowed, and that is leading to an extra "phantom" parameter to be added to the list of parameters detected (because of the way we manage tokens.

With this change, any empty returned token (without name and type) will be ignored, because that's the case when parsing the params and they have trailing commas.

Covered with tests using all the possible combinations of method declarations (all them valid).