### PR TITLE
Look further for first non-comment/white space line

### DIFF
--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -77,7 +77,7 @@ function local_moodlecheck_filephpdocpresent(local_moodlecheck_file $file) {
     }
     if ($file->find_file_phpdocs() === false) {
         $tokens = &$file->get_tokens();
-        for ($i = 0; $i < 30; $i++) {
+        for ($i = 0; $i < 90; $i++) {
             if (isset($tokens[$i]) && !in_array($tokens[$i][0], array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT))) {
                 return array(array('line' => $file->get_line_number($i)));
             }


### PR DESCRIPTION
The PHP 8.x tokenizer now provides more granular results than the one in previous PHP versions. Specifically about whitespace.

For example, every comment (//) line was previously reported as a list of T_COMMENT tokens (all together). And now it's a list of T_COMMENT + T_WHITESPACE.  So they almost double.

Hence, we are here allowing the code to look for the 1st line not being comments further, from old 30 (that was enough for files with non-standard comments header like config-dist.php) to 90 (3x), to ensure that there are more chances to find that first non-comment line.

Note that CiBoT reports all problems detected not having a line specified, so config-dist.php was being reported always. With this change it will come with a line found... and it won't be reported any more.