### PR TITLE
Anon classes with params do not required phpdocs either

### DIFF
--- a/file.php
+++ b/file.php
@@ -222,17 +222,37 @@ class local_moodlecheck_file {
                     if ($this->previous_nonspace_token($tid) == 'new') {
                         // This looks to be an anonymous class.
 
-                        if ($this->next_nonspace_token($tid) == '{') {
+                        $tpid = $tid; // Let's keep the original $tid and use own for anonymous searches.
+                        if ($this->next_nonspace_token($tpid) == '(') {
+                            // It may be an anonymous class with parameters, let's skip them
+                            // by advancing till we find the corresponding bracket closing token.
+                            $level = 0; // To control potential nesting of brackets within the params.
+                            while ($tpid = $this->next_nonspace_token($tpid, true)) {
+                                if ($this->tokens[$tpid][1] == '(') {
+                                    $level++;
+                                }
+                                if ($this->tokens[$tpid][1] == ')') {
+                                    $level--;
+                                    // We are back to level 0, we are done (have walked over all params).
+                                    if ($level === 0) {
+                                        $tpid = $tpid;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        if ($this->next_nonspace_token($tpid) == '{') {
                             // An anonymous class in the format `new class {`.
                             continue;
                         }
 
-                        if ($this->next_nonspace_token($tid) == 'extends') {
+                        if ($this->next_nonspace_token($tpid) == 'extends') {
                             // An anonymous class in the format `new class extends otherclasses {`.
                             continue;
                         }
 
-                        if ($this->next_nonspace_token($tid) == 'implements') {
+                        if ($this->next_nonspace_token($tpid) == 'implements') {
                             // An anonymous class in the format `new class implements someinterface {`.
                             continue;
                         }

--- a/tests/fixtures/anonymous/anonymous_with_params.php
+++ b/tests/fixtures/anonymous/anonymous_with_params.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class (
+    10,
+    $units,
+    new something(),
+    $end
+)
+{
+};

--- a/tests/fixtures/anonymous/extends_with_params.php
+++ b/tests/fixtures/anonymous/extends_with_params.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class (10, $units, new something(), $end) extends parentclass {
+};

--- a/tests/fixtures/anonymous/implements_with_params.php
+++ b/tests/fixtures/anonymous/implements_with_params.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for a fixture file in moodlecheck.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+return new class (10, $units, new something(), $end) implements someinterface {
+};

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -379,6 +379,18 @@ class moodlecheck_rules_test extends \advanced_testcase {
                 "{$rootpath}/extendsandimplements.php",
                 false,
             ],
+            'return new class (with params) {' => [
+                "{$rootpath}/anonymous_with_params.php",
+                false,
+            ],
+            'return new class (with params) extends parentclass {' => [
+                "{$rootpath}/extends_with_params.php",
+                false,
+            ],
+            'return new class (with params) implements someinterface {' => [
+                "{$rootpath}/implements_with_params.php",
+                false,
+            ],
             '$value = new class {' => [
                 "{$rootpath}/assigned.php",
                 false,


### PR DESCRIPTION
We already were supporting anon classes, allowing them not to be documented.

This PR just enables anon classes with params to follow the same path. We'll just skip any (between brackets) parameters in the class declaration and will continue looking for a extends/implements/body like we were doing already.

Note this fixes #91 