### PR TITLE
Add severity information to text and html formats

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -88,8 +88,10 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
             if ($format == 'html' || $format == 'text') {
                 $error['message'] .= ' (' . $error['severity'] . ')';
             }
-            if (($format == 'html' || $format == 'text') && isset($error['line']) && strlen($error['line'])) {
-                $error['message'] = get_string('linenum', 'local_moodlecheck', $error['line']). $error['message'];
+
+            // Prepend the line number, if available.
+            if (($format == 'html' || $format == 'text') && isset($error['line']) && $error['line'] !== '') {
+                $error['message'] = get_string('linenum', 'local_moodlecheck', $error['line']) . $error['message'];
             }
             if ($format == 'html') {
                 $output .= html_writer::tag('li', $error['message'], array('class' => 'errorline'));

--- a/renderer.php
+++ b/renderer.php
@@ -84,6 +84,10 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
             $output .= $filename. "\n";
         }
         foreach ($errors as $error) {
+            // Add the severity always to both text and html formats.
+            if ($format == 'html' || $format == 'text') {
+                $error['message'] .= ' (' . $error['severity'] . ')';
+            }
             if (($format == 'html' || $format == 'text') && isset($error['line']) && strlen($error['line'])) {
                 $error['message'] = get_string('linenum', 'local_moodlecheck', $error['line']). $error['message'];
             }

--- a/tests/coverage.php
+++ b/tests/coverage.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Coverage information for the local_codechecker plugin.
+ *
+ * @package   local_moodlecheck
+ * @category  test
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Anonymous phpunit_coverage_info returning the areas to include and exclude.
+ */
+return new class extends phpunit_coverage_info {
+    /** @var array The list of folders relative to the plugin root to include in coverage generation. */
+    protected $includelistfolders = [
+        'rules'
+    ];
+
+    /** @var array The list of files relative to the plugin root to include in coverage generation. */
+    protected $includelistfiles = [
+        'file.php'
+    ];
+
+    /** @var array The list of folders relative to the plugin root to exclude from coverage generation. */
+    protected $excludelistfolders = [];
+
+    /** @var array The list of files relative to the plugin root to exclude from coverage generation. */
+    protected $excludelistfiles = [];
+};

--- a/tests/fixtures/error_and_warning.php
+++ b/tests/fixtures/error_and_warning.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Fixture file providing a class with a method without phpdoc.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class someclass extends parentclass {
+    public function somefunc() {
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -525,4 +525,42 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $this->assertStringContainsString('$undocumented3', $found->item(2)->getAttribute("message"));
         $this->assertStringContainsString('$undocumented4', $found->item(3)->getAttribute("message"));
     }
+
+    /**
+     * Verify that the text format shown information about the severity of the problem (error vs warning)
+     *
+     * @covers \local_moodlecheck_renderer
+     */
+    public function test_text_format_errors_and_warnings() {
+        $file = __DIR__ . "/fixtures/error_and_warning.php";
+
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path($file, null);
+        $result = $output->display_path($path, 'text');
+
+        $this->assertStringContainsString('tests/fixtures/error_and_warning.php', $result);
+        $this->assertStringContainsString('2: Empty line found after PHP open tag (warning)', $result);
+        $this->assertStringContainsString('11: Class someclass is not documented (error)', $result);
+        $this->assertStringContainsString('12: Function someclass::somefunc is not documented (warning)', $result);
+    }
+
+    /**
+     * Verify that the html format shown information about the severity of the problem (error vs warning)
+     *
+     * @covers \local_moodlecheck_renderer
+     */
+    public function test_html_format_errors_and_warnings() {
+        $file = __DIR__ . "/fixtures/error_and_warning.php";
+
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path($file, null);
+        $result = $output->display_path($path, 'html');
+
+        $this->assertStringContainsString('tests/fixtures/error_and_warning.php</span>', $result);
+        $this->assertStringContainsString('<b>2</b>: Empty line found after PHP open tag (warning)', $result);
+        $this->assertStringContainsString('<b>11</b>: Class <b>someclass</b> is not documented (error)', $result);
+        $this->assertStringContainsString('<b>12</b>: Function <b>someclass::somefunc</b> is not documented (warning)', $result);
+    }
 }


### PR DESCRIPTION
Note that the xml format already includes that severity (error or warning) information.

Covered with unit tests, we also are introducing here a coverage.php file to add some locations that are not considered by default.

We need that information to be able to discern, with other tools, between warning and errors. See for example https://github.com/moodlehq/moodle-plugin-ci/issues/186

Ciao :-)