### PR TITLE
Support "use function" and "use const"

### DIFF
--- a/tests/fixtures/uses.php
+++ b/tests/fixtures/uses.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture file with use statements, none of which should trigger warnings, despite containing "function" and "const".
+ *
+ * @package     local_moodlecheck
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use these\dont\actually\need\to\point\to\anything;
+use function ns\fun_1;
+use function ns\fun_2 as alias;
+use const ns\CONST_1;
+use const ns\CONST_2 as ALIAS;
+
+use {
+    function ns\fun_3,
+    const ns\const_3
+};
+
+use function ns\fun_1?>

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -496,6 +496,30 @@ class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify that "use function" statements are ignored.
+     *
+     * @covers ::local_moodlecheck_functionsdocumented
+     * @covers ::local_moodlecheck_constsdocumented
+     */
+    public function test_functionsdocumented_constsdocumented_ignore_uses() {
+        $file = __DIR__ . "/fixtures/uses.php";
+
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path($file, null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Object.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query('//file/error[@source="functionsdocumented" or @source="constsdocumented"]');
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(0, $found->length);
+    }
+
+    /**
      * Verify that `variablesdocumented` correctly detects PHPdoc on different kinds of properties.
      *
      * @covers ::local_moodlecheck_variablesdocumented


### PR DESCRIPTION
`get_functions` and `get_constants` previously interpreted these statements as functions and constants themselves, leading to false positives.

It would have been somewhat simpler to check if the `T_FUNCTION`/`T_CONST` is directly preceded by a `T_USE`, but that doesn't support the "grouped" use statements. (`use { function a, const B };`) Instead, I skip to the next semicolon (or ?> or EOF) when T_USE is encountered.