### PR TITLE
Constructor property promotion

### DIFF
--- a/file.php
+++ b/file.php
@@ -400,12 +400,19 @@ class local_moodlecheck_file {
                                 case T_ELLIPSIS:
                                     // Variadic function.
                                     $splat = true;
-                                    break;
+                                    continue 2;
                             }
                             switch ($argtokens[$j][1]) {
                                 case '|':
                                 case '&':
                                     continue 2;
+                                    continue 2;
+                                case '?':
+                                    $possibletypes[] = 'null';
+                                    continue 2;
+                                case '=':
+                                    // Default value.
+                                    $j = count($argtokens);
                                     continue 2;
                             }
 
@@ -745,6 +752,7 @@ class local_moodlecheck_file {
     public function find_preceeding_phpdoc($tid) {
         $tokens = &$this->get_tokens();
         $modifiers = $this->find_access_modifiers($tid);
+
         for ($i = $tid - 1; $i >= 0; $i--) {
             if ($this->is_whitespace_token($i)) {
                 if ($this->is_multiline_token($i) > 1) {
@@ -1322,8 +1330,18 @@ class local_moodlecheck_phpdocs {
      */
     public function get_params($tag = 'param', $splitlimit = 3) {
         $params = array();
+
         foreach ($this->get_tags($tag) as $token) {
             $params[] = preg_split('/\s+/', trim($token), $splitlimit); // AKA 'type $name multi-word description'.
+        }
+
+        foreach ($params as $key => $param) {
+            if (strpos($param[0], '?') !== false) {
+                $param[0] = str_replace('?', 'null|', $param[0]);
+            }
+            $types = explode('|', $param[0]);
+            sort($types);
+            $params[$key][0] = implode('|', $types);
         }
         return $params;
     }

--- a/file.php
+++ b/file.php
@@ -382,21 +382,37 @@ class local_moodlecheck_file {
                         if (empty($argtokens)) {
                             continue;
                         }
+                        $possibletypes = [];
                         $type = null;
                         $variable = null;
                         $splat = false;
+
                         for ($j = 0; $j < count($argtokens); $j++) {
-                            if ($argtokens[$j][0] == T_VARIABLE) {
-                                $variable = ($splat) ? '...'.$argtokens[$j][1] : $argtokens[$j][1];
-                                break;
-                            } else if ($argtokens[$j][0] != T_WHITESPACE &&
-                                    $argtokens[$j][0] != T_ELLIPSIS && $argtokens[$j][1] != '&') {
-                                $type = $argtokens[$j][1];
-                            } else if ($argtokens[$j][0] == T_ELLIPSIS) {
-                                // Variadic function.
-                                $splat = true;
+                            switch ($argtokens[$j][0]) {
+                                case T_WHITESPACE:
+                                case T_PUBLIC:
+                                case T_PROTECTED:
+                                case T_WHITESPACE:
+                                    continue 2;
+                                case T_VARIABLE:
+                                    $variable = ($splat) ? '...' . $argtokens[$j][1] : $argtokens[$j][1];
+                                    continue 2;
+                                case T_ELLIPSIS:
+                                    // Variadic function.
+                                    $splat = true;
+                                    break;
                             }
+                            switch ($argtokens[$j][1]) {
+                                case '|':
+                                case '&':
+                                    continue 2;
+                                    continue 2;
+                            }
+
+                            $possibletypes[] = $argtokens[$j][1];
                         }
+
+                        $type = implode('|', $possibletypes);
 
                         // PHP 8 treats namespaces as single token. So we are going to undo this here
                         // and continue returning only the final part of the namespace. Someday we'll

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -436,6 +436,17 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
 
+                    if (strpos($expectedtype, '|' ) !== false) {
+                        $types = explode('|', $expectedtype);
+                        sort($types);
+                        $expectedtype = implode('|', $types);
+                    }
+                    if (strpos($documentedtype, '|' ) !== false) {
+                        $types = explode('|', $documentedtype);
+                        sort($types);
+                        $documentedtype = implode('|', $types);
+                    }
+
                     $typematch = $expectedtype === $documentedtype;
                     $parammatch = $expectedparam === $documentedparam;
                     if ($typematch && $parammatch) {

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -421,6 +421,7 @@ function local_moodlecheck_functiondescription(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
     $errors = array();
+
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs !== false) {
             $documentedarguments = $function->phpdocs->get_params();
@@ -434,6 +435,12 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                     $expectedparam = (string)$function->arguments[$i][1];
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
+
+                    $typematch = $expectedtype === $documentedtype;
+                    $parammatch = $expectedparam === $documentedparam;
+                    if ($typematch && $parammatch) {
+                        continue;
+                    }
 
                     // Documented types can be a collection (| separated).
                     foreach (explode('|', $documentedtype) as $documentedtype) {

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -74,6 +74,7 @@ function local_moodlecheck_packagespecified(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_packagevalid(local_moodlecheck_file $file) {
     $errors = array();
+
     $allowedpackages = local_moodlecheck_package_names($file);
     foreach ($file->get_all_phpdocs() as $phpdoc) {
         foreach ($phpdoc->get_tags('package') as $package) {

--- a/tests/fixtures/phpdoc_constructor_property_promotion.php
+++ b/tests/fixtures/phpdoc_constructor_property_promotion.php
@@ -14,14 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * A fixture to verify various phpdoc tags in a general location.
- *
- * @package   local_moodlecheck
- * @copyright 2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 use cm_info;
 use stdClass;
 
@@ -38,10 +30,16 @@ class constructor_property_promotion {
      *
      * @param stdClass|cm_info $cm The course module data
      * @param string $name The name
+     * @param int|float $size The size
+     * @param null|string $description The description
+     * @param ?string $content The content
      */
     public function __construct(
         protected stdClass|cm_info $cm,
         protected string $name,
+        protected float|int $size,
+        protected ?string $description = null,
+        protected ?string $content = null
     ) {
     }
 }

--- a/tests/fixtures/phpdoc_constructor_property_promotion.php
+++ b/tests/fixtures/phpdoc_constructor_property_promotion.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A fixture to verify various phpdoc tags in a general location.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use cm_info;
+use stdClass;
+
+/**
+ * A fixture to verify various phpdoc tags in a general location.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class constructor_property_promotion {
+    /**
+     * An example of a constructor using constructor property promotion.
+     *
+     * @param stdClass|cm_info $cm The course module data
+     * @param string $name The name
+     */
+    public function __construct(
+        protected stdClass|cm_info $cm,
+        protected string $name,
+    ) {
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -199,6 +199,31 @@ class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify that constructor property promotion is supported.
+     *
+     * @covers ::local_moodlecheck_functionarguments
+     */
+    public function test_phpdoc_constructor_property_promotion() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_constructor_property_promotion.php ', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 8 children.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(2, $found->length);
+        $this->assertStringNotContainsString('constructor_property_promotion::__construct has incomplete parameters list', $result);
+
+    }
+
+    /**
      * Verify various phpdoc tags in tests directories.
      *
      * @covers ::local_moodlecheck_phpdocsinvalidtag

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -69,6 +69,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
         // Let's verify we have received a xml with file top element and 2 children.
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
+
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
         $this->assertSame(2, $found->length);
 
@@ -218,9 +219,9 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $found = $xpath->query("//file/error");
 
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(2, $found->length);
+        $this->assertSame(1, $found->length);
         $this->assertStringNotContainsString('constructor_property_promotion::__construct has incomplete parameters list', $result);
-
+        $this->assertStringContainsString('packagevalid', $result);
     }
 
     /**


### PR DESCRIPTION
I'm not 100% sure that this was entirely due to constructor property promotion but this addresses the reported issue as well as:
- support for union types
- nullable normalisation (? vs null|)
- order of union types