### PR TITLE
Union types

### DIFF
--- a/file.php
+++ b/file.php
@@ -388,21 +388,40 @@ class local_moodlecheck_file {
                         if (empty($argtokens)) {
                             continue;
                         }
-                        $type = null;
+                        $possibletypes = [];
                         $variable = null;
                         $splat = false;
+
                         for ($j = 0; $j < count($argtokens); $j++) {
-                            if ($argtokens[$j][0] == T_VARIABLE) {
-                                $variable = ($splat) ? '...'.$argtokens[$j][1] : $argtokens[$j][1];
-                                break;
-                            } else if ($argtokens[$j][0] != T_WHITESPACE &&
-                                    $argtokens[$j][0] != T_ELLIPSIS && $argtokens[$j][1] != '&') {
-                                $type = $argtokens[$j][1];
-                            } else if ($argtokens[$j][0] == T_ELLIPSIS) {
-                                // Variadic function.
-                                $splat = true;
+                            switch ($argtokens[$j][0]) {
+                                // Skip any whitespace, or argument visibility.
+                                case T_WHITESPACE:
+                                case T_PUBLIC:
+                                case T_PROTECTED:
+                                case T_PRIVATE:
+                                    continue 2;
+                                case T_VARIABLE:
+                                    // The variale name, adding in the vardiadic if required.
+                                    $variable = ($splat) ? '...' . $argtokens[$j][1] : $argtokens[$j][1];
+                                    continue 2;
+                                case T_ELLIPSIS:
+                                    // For example ...$example
+                                    // Variadic function.
+                                    $splat = true;
+                                    break;
                             }
+                            switch ($argtokens[$j][1]) {
+                                case '|':
+                                    // Union types.
+                                case '&':
+                                    // Return by reference.
+                                    continue 2;
+                            }
+
+                            $possibletypes[] = $argtokens[$j][1];
                         }
+
+                        $type = implode('|', $possibletypes);
 
                         // PHP 8 treats namespaces as single token. So we are going to undo this here
                         // and continue returning only the final part of the namespace. Someday we'll

--- a/file.php
+++ b/file.php
@@ -1380,6 +1380,13 @@ class local_moodlecheck_phpdocs {
                 $param[0] = str_replace('?', 'null|', $param[0]);
             }
             $types = explode('|', $param[0]);
+            $types = array_map(function($type): string {
+                // Normalise array types such as `string[]` to `array`.
+                if (substr($type, -2) == '[]') {
+                    return 'array';
+                }
+                return $type;
+            }, $types);
             sort($types);
             $params[$key][0] = implode('|', $types);
         }

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -436,6 +436,17 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
 
+                    if (strpos($expectedtype, '|' ) !== false) {
+                        $types = explode('|', $expectedtype);
+                        sort($types);
+                        $expectedtype = implode('|', $types);
+                    }
+                    if (strpos($documentedtype, '|' ) !== false) {
+                        $types = explode('|', $documentedtype);
+                        sort($types);
+                        $documentedtype = implode('|', $types);
+                    }
+
                     $typematch = $expectedtype === $documentedtype;
                     $parammatch = $expectedparam === $documentedparam;
                     if ($typematch && $parammatch) {

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -421,6 +421,7 @@ function local_moodlecheck_functiondescription(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
     $errors = array();
+
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs !== false) {
             $documentedarguments = $function->phpdocs->get_params();
@@ -434,6 +435,12 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                     $expectedparam = (string)$function->arguments[$i][1];
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
+
+                    $typematch = $expectedtype === $documentedtype;
+                    $parammatch = $expectedparam === $documentedparam;
+                    if ($typematch && $parammatch) {
+                        continue;
+                    }
 
                     // Documented types can be a collection (| separated).
                     foreach (explode('|', $documentedtype) as $documentedtype) {

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -74,6 +74,7 @@ function local_moodlecheck_packagespecified(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_packagevalid(local_moodlecheck_file $file) {
     $errors = array();
+
     $allowedpackages = local_moodlecheck_package_names($file);
     foreach ($file->get_all_phpdocs() as $phpdoc) {
         foreach ($phpdoc->get_tags('package') as $package) {

--- a/tests/fixtures/phpdoc_constructor_property_promotion.php
+++ b/tests/fixtures/phpdoc_constructor_property_promotion.php
@@ -1,0 +1,41 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_moodlecheck;
+
+use cm_info;
+use stdClass;
+
+/**
+ * A fixture to verify phpdoc tags used in constructor property promotion.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class constructor_property_promotion {
+    /**
+     * An example of a constructor using constructor property promotion.
+     *
+     * @param stdClass|cm_info $cm The course module data
+     * @param string $name The name
+     */
+    public function __construct(
+        private stdClass|cm_info $cm,
+        protected string $name,
+    ) {
+    }
+}

--- a/tests/fixtures/phpdoc_constructor_property_promotion.php
+++ b/tests/fixtures/phpdoc_constructor_property_promotion.php
@@ -32,10 +32,16 @@ class constructor_property_promotion {
      *
      * @param stdClass|cm_info $cm The course module data
      * @param string $name The name
+     * @param int|float $size The size
+     * @param null|string $description The description
+     * @param ?string $content The content
      */
     public function __construct(
         private stdClass|cm_info $cm,
         protected string $name,
+        protected float|int $size,
+        protected ?string $description = null,
+        protected ?string $content = null
     ) {
     }
 }

--- a/tests/fixtures/phpdoc_method_union_types.php
+++ b/tests/fixtures/phpdoc_method_union_types.php
@@ -1,0 +1,92 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_moodlecheck;
+
+/**
+ * A fixture to verify various phpdoc tags in a general location.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class union_types {
+    /**
+     * An example of a method on a single line using union types in both the params and return values
+     * @param string|int $value
+     * @return string|int
+     */
+    public function method_oneline(string|int $value): string|int {
+        // Do something.
+        return $value;
+    }
+
+    /**
+     * An example of a method on a single line using union types in both the params and return values
+     *
+     * @param string|int $value
+     * @param int|float $othervalue
+     * @return string|int
+     */
+    public function method_oneline_multi(string|int $value, int|float $othervalue): string|int {
+        // Do something.
+        return $value;
+    }
+
+    /**
+     * An example of a method on a single line using union types in both the params and return values
+     *
+     * @param string|int $value
+     * @param int|float $othervalue
+     * @return string|int
+     */
+    public function method_multiline(
+        string|int $value,
+        int|float $othervalue,
+    ): string|int {
+        // Do something.
+        return $value;
+    }
+
+    /**
+     * An example of a method whose union values are not in the same order.
+
+     * @param int|string $value
+     * @param int|float $othervalue
+     * @return int|string
+     */
+    public function method_union_order_does_not_matter(
+        string|int $value,
+        float|int $othervalue,
+    ): string|int {
+        // Do something.
+        return $value;
+    }
+
+    /**
+     * An example of a method which uses strings, or an array of strings.
+     *
+     * @param string|string[] $arrayofstrings
+     * @return string[]|string
+     */
+    public function method_union_containing_array(
+        string|array $arrayofstrings,
+    ): string|array {
+        return [
+            'example',
+        ];
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -199,6 +199,80 @@ class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify that constructor property promotion is supported.
+     *
+     * @covers ::local_moodlecheck_functionarguments
+     */
+    public function test_phpdoc_constructor_property_promotion() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_constructor_property_promotion.php ', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 8 children.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(1, $found->length);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringNotContainsString('constructor_property_promotion::__construct has incomplete parameters list', $result);
+    }
+
+    /**
+     * Verify that constructor property promotion is supported.
+     *
+     * @covers ::local_moodlecheck_functionarguments
+     */
+    public function test_phpdoc_union_types() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_method_union_types.php ', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 8 children.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(1, $found->length);
+        $this->assertStringContainsString('packagevalid', $result);
+        $this->assertStringNotContainsString(
+            'constructor_property_promotion::__construct has incomplete parameters list',
+            $result
+         );
+        $this->assertStringNotContainsString(
+            'Phpdocs for function union_types::method_oneline has incomplete parameters list',
+            $result
+        );
+        $this->assertStringNotContainsString(
+            'Phpdocs for function union_types::method_oneline_multi has incomplete parameters list',
+            $result
+        );
+        $this->assertStringNotContainsString(
+            'Phpdocs for function union_types::method_multiline has incomplete parameters list',
+            $result
+        );
+        $this->assertStringNotContainsString(
+            'Phpdocs for function union_types::method_union_order_does_not_matter has incomplete parameters list',
+            $result
+        );
+        $this->assertStringNotContainsString(
+            'Phpdocs for function union_types::method_union_containing_array has incomplete parameters list',
+            $result
+        );
+    }
+
+    /**
      * Verify various phpdoc tags in tests directories.
      *
      * @covers ::local_moodlecheck_phpdocsinvalidtag

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -69,6 +69,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
         // Let's verify we have received a xml with file top element and 2 children.
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
+
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
         $this->assertSame(2, $found->length);
 


### PR DESCRIPTION
This is a bit of a mixed bag, but the original thing came from adding support for union types.
When writing the testcases I discovered that we did not support:
* union types (that is `string|int|float`)
* mis-ordered params (that is `int|float` in docs, and `float|int` in the type hint)
* nullable types (that is `?string`)
* array types in docs (that is `string[]`)

This series of commits:
* adds tests which cover all of these features
* adds support for union types
* adds support for nullable types
* adds support for array type normalisation
* normalises the order of types and param docs

As part of this change I've tried to improve the token parsing to be clearer too.