### PR TITLE
Normalise php 7.4 class namespaces

### DIFF
--- a/file.php
+++ b/file.php
@@ -374,6 +374,7 @@ class local_moodlecheck_file {
                     } else {
                         $function->tagpair = false;
                     }
+
                     $argumentspair = $this->find_tag_pair($tid, '(', ')', array('{', ';'));
                     if ($argumentspair !== false && $argumentspair[1] - $argumentspair[0] > 1) {
                         $function->argumentstokens = $this->break_tokens_by(
@@ -391,6 +392,49 @@ class local_moodlecheck_file {
                         $possibletypes = [];
                         $variable = null;
                         $splat = false;
+
+                        if (PHP_VERSION_ID < 80000) {
+                            // In PHP 7.4 and earlier, the namespace was parsed separately, for example:
+                            // \core\course would be come '\', 'core', '\', 'course'.
+                            // From PHP 8.0 this becomes '\core\course'.
+                            // To address this we modify the tokens to match the PHP 8.0 format.
+                            // This is a bit of a hack, but it works.
+                            // Note: argtokens contains arrays of [token index, string content, line number].
+                            for ($j = 0; $j < count($argtokens); $j++) {
+                                if ($argtokens[$j][0] === T_NS_SEPARATOR && count($argtokens) > $j + 1) {
+                                    // If the token is a literal backslash, then
+                                    // append future tokens until we find a non-namespace token.
+                                    $argtokens[$j][0] = T_STRING;
+                                    $initialtoken = $j;
+                                    for ($namespacetoken = $j + 1; $namespacetoken < count($argtokens); $namespacetoken++) {
+                                        switch ($argtokens[$namespacetoken][1]) {
+                                            case '|':
+                                            case '=':
+                                                break 2;
+                                        }
+                                        $argtokens[$initialtoken][1] .= $argtokens[$namespacetoken][1];
+                                        unset($argtokens[$namespacetoken]);
+                                        $j = $namespacetoken;
+                                    }
+                                } else if (count($argtokens) <= $j && $argtokens[$j + 1][0] === T_NS_SEPARATOR) {
+                                    // If the next token is a literal backslash, then
+                                    // append future tokens until we find a non-namespace token.
+                                    $argtokens[$j][0] = T_STRING;
+                                    $initialtoken = $j;
+                                    for ($namespacetoken = $j + 1; $namespacetoken < count($argtokens); $namespacetoken++) {
+                                        switch ($argtokens[$namespacetoken][1]) {
+                                            case '|':
+                                            case '=':
+                                                break 2;
+                                        }
+                                        $argtokens[$initialtoken][1] .= $argtokens[$namespacetoken][1];
+                                        unset($argtokens[$namespacetoken]);
+                                        $j = $namespacetoken;
+                                    }
+                                }
+                            }
+                        }
+                        $argtokens = array_values($argtokens);
 
                         for ($j = 0; $j < count($argtokens); $j++) {
                             switch ($argtokens[$j][0]) {

--- a/tests/fixtures/phpdoc_tags_general.php
+++ b/tests/fixtures/phpdoc_tags_general.php
@@ -230,4 +230,16 @@ class fixturing_general {
     public function correct_return_type(): string {
         return "yay!";
     }
+
+    /**
+     * Namespaced types.
+     *
+     * @param \core\user $user
+     * @return \core\user
+     */
+    public function namespaced_parameter_type(
+        \core\user $user
+    ): \core\user {
+        return $user;
+    }
 }


### PR DESCRIPTION
In PHP 7.4 the object type in a parameter or return type were tokenised to individual namespace components. For example:

    \core\course

Becomes

    \
     core
         \
          course

From PHP 8.0, it is tokenized to \core\course.

This change attempts to normalise these values.

Fixes #116