### PR TITLE
Parse types for validity, and smarter checking

### DIFF
--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -88,6 +88,12 @@ class type_parser {
                 if ($this->nextpos < strlen($text) && !(ctype_space($text[$this->nextpos]) || $this->nexttoken == '=')) {
                     throw new \Error("Error parsing type, no space at end of variable.");
                 }
+                if ($this->nexttoken == '=') {
+                    $this->parse_token('=');
+                    if ($this->nexttoken == 'null' && $type != null) {
+                        $type = $type . '|void';
+                    }
+                }
             } catch (\Error $e) {
                 list($this->nextpos, $this->nexttoken, $this->nextnextpos) = $savedstate;
                 $variable = null;

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -468,7 +468,7 @@ class type_parser {
                 $next = '';
             }
             $this->nexts[] = (object)['startpos' => $startpos, 'endpos' => $endpos,
-                'text' => ($next !== '') ? $next : null,];
+                'text' => ($next !== '') ? $next : null, ];
         }
 
         // Return the needed token.
@@ -675,7 +675,7 @@ class type_parser {
             $type = 'bool';
         } else if (in_array($next, ['int', 'integer', 'positive-int', 'negative-int',
                                     'non-positive-int', 'non-negative-int',
-                                    'int-mask', 'int-mask-of',])
+                                    'int-mask', 'int-mask-of', ])
                 || (ctype_digit($nextchar) || $nextchar == '-') && strpos($next, '.') === false) {
             // Int.
             $inttype = $this->parse_token();
@@ -726,7 +726,7 @@ class type_parser {
             $this->parse_token();
             $type = 'float';
         } else if (in_array($next, ['string', 'class-string', 'numeric-string', 'literal-string',
-                                    'non-empty-string', 'non-falsy-string', 'truthy-string',])
+                                    'non-empty-string', 'non-falsy-string', 'truthy-string', ])
                     || $nextchar == '"' || $nextchar == '\'') {
             // String.
             $strtype = $this->parse_token();

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -304,9 +304,11 @@ class type_parser {
                     array_push($intersectiontypes, $this->parse_single_type());
                     // We have to figure out whether a & is for intersection or pass by reference.
                     // Dirty hack.  TODO: Do something better.
-                    $haveintersection = $this->nexttoken == '&' && ($this->nextnextpos < strlen($this->type))
-                        && ($havebracket || !(ctype_space($this->type[$this->nextpos])
-                                            xor ctype_space($this->type[$this->nextnextpos])));
+                    $haveintersection = $this->nexttoken == '&' && ($havebracket
+                        || !($this->nextnextpos >= strlen($this->type)
+                                || in_array($this->type[$this->nextnextpos], ['.', '=', '$', ',', ')']))
+                            && !(!ctype_space($this->type[$this->nextpos])
+                                && ctype_space($this->type[$this->nextnextpos])));
                     if ($haveintersection) {
                         $this->parse_token('&');
                     }

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -399,7 +399,8 @@ class type_parser {
                         foreach ($intersectiontypes as $intersectiontype) {
                             assert ($intersectiontype != '');
                             $supertypes = static::super_types($intersectiontype);
-                            if (!($intersectiontype == 'object' || in_array('object', $supertypes))) {
+                            if (!(in_array($intersectiontype, ['object', 'iterable', 'callable'])
+                                    || in_array('object', $supertypes))) {
                                 throw new \Exception("Error parsing type, intersection can only be used with objects.");
                             }
                             foreach ($supertypes as $supertype) {

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -152,11 +152,11 @@ class type_parser {
 
     /**
      * Constructor
-     * @param \local_moodlecheck_file $file
+     * @param ?\local_moodlecheck_file $file
      */
-    public function __construct(\local_moodlecheck_file $file) {
-        $this->usealiases = $file->get_use_aliases();
-        $this->artifacts = $file->get_artifacts_flat();
+    public function __construct(\local_moodlecheck_file $file = null) {
+        $this->usealiases = $file ? $file->get_use_aliases() : [];
+        $this->artifacts = $file ? $file->get_artifacts_flat() : [];
     }
 
     /**

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -468,7 +468,7 @@ class type_parser {
                 $next = '';
             }
             $this->nexts[] = (object)['startpos' => $startpos, 'endpos' => $endpos,
-                'text' => ($next !== '') ? $next : null];
+                'text' => ($next !== '') ? $next : null,];
         }
 
         // Return the needed token.
@@ -675,7 +675,7 @@ class type_parser {
             $type = 'bool';
         } else if (in_array($next, ['int', 'integer', 'positive-int', 'negative-int',
                                     'non-positive-int', 'non-negative-int',
-                                    'int-mask', 'int-mask-of'])
+                                    'int-mask', 'int-mask-of',])
                 || (ctype_digit($nextchar) || $nextchar == '-') && strpos($next, '.') === false) {
             // Int.
             $inttype = $this->parse_token();
@@ -726,7 +726,7 @@ class type_parser {
             $this->parse_token();
             $type = 'float';
         } else if (in_array($next, ['string', 'class-string', 'numeric-string', 'literal-string',
-                                    'non-empty-string', 'non-falsy-string', 'truthy-string'])
+                                    'non-empty-string', 'non-falsy-string', 'truthy-string',])
                     || $nextchar == '"' || $nextchar == '\'') {
             // String.
             $strtype = $this->parse_token();

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -1,0 +1,594 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_moodlecheck;
+
+/**
+ * Type parser
+ *
+ * Checks that PHPDoc types are well formed, and returns a simplified version if so, or null otherwise.
+ *
+ * @package     local_moodlecheck
+ * @copyright   2023 Te Pūkenga – New Zealand Institute of Skills and Technology
+ * @author      James Calder
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class type_parser {
+
+    /** @var string the type to be parsed */
+    protected $type;
+
+    /** @var non-negative-int the position of the next token */
+    protected $nextpos;
+
+    /** @var ?non-empty-string the next token */
+    protected $nexttoken;
+
+    /** @var non-negative-int the position after the next token */
+    protected $nextnextpos;
+
+    /**
+     * Parse the whole type
+     *
+     * @param string $type the type to parse
+     * @return array{?non-empty-string, string} the simplified type, and remaining text
+     */
+    public function parse_type(string $type): array {
+
+        // Initialise variables.
+        $this->type = strtolower($type);
+        $this->nextnextpos = 0;
+        $this->prefetch_next_token();
+
+        // Try to parse.
+        try {
+            $result = $this->parse_dnf_type();
+            if ($this->nextpos < strlen($type) && !ctype_space($type[$this->nextpos])) {
+                throw new \Error("Error parsing type, no space at end");
+            }
+            return [$result, substr($type, $this->nextpos)];
+        } catch (\Error $e) {
+            return [null, $type];
+        }
+
+    }
+
+    /**
+     * Compare types
+     *
+     * @param ?string $widetypes the type that should be wider
+     * @param ?string $narrowtypes the type that should be narrower
+     * @return bool whether $narrowtypes has the same or narrower scope as $widetypes
+     */
+    public static function compare_types(?string $widetypes, ?string $narrowtypes): bool {
+        if ($narrowtypes == null || $narrowtypes == '') {
+            return false;
+        } else if ($widetypes == null || $widetypes == '' || $widetypes == 'mixed'
+                || $narrowtypes == 'never') {
+            return true;
+        }
+
+        $wideintersections = explode('|', $widetypes);
+        $narrowintersections = explode('|', $narrowtypes);
+
+        // We have to match all documented intersections.
+        $haveallintersections = true;
+        foreach ($narrowintersections as $narrowintersection) {
+            $narrowsingles = explode('&', $narrowintersection);
+
+            // If the expected types are super types, that should match.
+            $narrowadditions = [];
+            foreach ($narrowsingles as $narrowsingle) {
+                if ($narrowsingle == 'int') {
+                    $supertypes = ['array-key', 'float', 'scalar'];
+                } else if ($narrowsingle == 'string') {
+                    $supertypes = ['array-key', 'scaler'];
+                } else if ($narrowsingle == 'callable-string') {
+                    $supertypes = ['callable', 'string', 'array-key', 'scalar'];
+                } else if (in_array($narrowsingle, ['array-key', 'bool', 'float'])) {
+                    $supertypes = ['scalar'];
+                } else if ($narrowsingle == 'array') {
+                    $supertypes = ['iterable'];
+                } else if ($narrowsingle == 'Traversable') {
+                    $supertypes = ['iterable', 'object'];
+                } else if (in_array($narrowsingle, ['self', 'parent', 'static'])
+                        || $narrowsingle[0] >= 'A' && $narrowsingle[0] <= 'Z' || $narrowsingle[0] == '_') {
+                    $supertypes = ['object'];
+                } else {
+                    $supertypes = [];
+                }
+                $narrowadditions = array_merge($narrowadditions, $supertypes);
+            }
+            $narrowsingles = array_merge($narrowsingles, $narrowadditions);
+            sort($narrowsingles);
+            $narrowsingles = array_unique($narrowsingles);
+
+            // We need to look in each expected intersection.
+            $havethisintersection = false;
+            foreach ($wideintersections as $wideintersection) {
+                $widesingles = explode('&', $wideintersection);
+
+                // And find all parts of one of them.
+                $haveallsingles = true;
+                foreach ($widesingles as $widesingle) {
+
+                    if (!in_array($widesingle, $narrowsingles)) {
+                        $haveallsingles = false;
+                        break;
+                    }
+
+                }
+                if ($haveallsingles) {
+                    $havethisintersection = true;
+                    break;
+                }
+            }
+            if (!$havethisintersection) {
+                $haveallintersections = false;
+                break;
+            }
+        }
+        return $haveallintersections;
+    }
+
+    /**
+     * Prefetch next token
+     */
+    protected function prefetch_next_token(): void {
+
+        $startpos = $this->nextnextpos;
+
+        // Ignore whitespace.
+        while ($startpos < strlen($this->type) && ctype_space($this->type[$startpos])) {
+            $startpos++;
+        }
+
+        $firstchar = ($startpos < strlen($this->type)) ? $this->type[$startpos] : null;
+
+        // Deal with different types of tokens.
+        if ($firstchar == null) {
+            // No more tokens.
+            $endpos = $startpos;
+        } else if (ctype_digit($firstchar) || $firstchar == '-') {
+            // Number token.
+            $nextchar = $firstchar;
+            $havepoint = false;
+            $endpos = $startpos;
+            do {
+                $havepoint = $havepoint || $nextchar == '.';
+                $endpos = $endpos + 1;
+                $nextchar = ($endpos < strlen($this->type)) ? $this->type[$endpos] : null;
+            } while ($nextchar != null && (ctype_digit($nextchar) || $nextchar == '.' && !$havepoint));
+        } else if (ctype_alpha($firstchar) || $firstchar == '_' || $firstchar == '$' || $firstchar == '\\') {
+            // Identifier token.
+            $endpos = $startpos;
+            do {
+                $endpos = $endpos + 1;
+                $nextchar = ($endpos < strlen($this->type)) ? $this->type[$endpos] : null;
+            } while ($nextchar != null && (ctype_alnum($nextchar) || $nextchar == '_'
+                                        || $firstchar != '$' && ($nextchar == '-' || $nextchar == '\\')));
+        } else if ($firstchar == '"' || $firstchar == "'") {
+            // String token.
+            $endpos = $startpos;
+            $nextchar = $firstchar;
+            do {
+                if ($nextchar == null) {
+                    throw new \Error('Error parsing type, unterminated string');
+                }
+                $endpos = $endpos + 1;
+                $lastchar = $nextchar;
+                $nextchar = ($endpos < strlen($this->type)) ? $this->type[$endpos] : null;
+            } while ($lastchar != $firstchar || $endpos == $startpos + 1);
+        } else if (strlen($this->type) >= $startpos + 3 && substr($this->type, $startpos, 3) == '...') {
+            // Splat.
+            $endpos = $startpos + 3;
+        } else {
+            // Other symbol token.
+            $endpos = $startpos + 1;
+        }
+
+        // Store token.
+        $this->nextpos = $this->nextnextpos;
+        $this->nexttoken = ($endpos > $startpos) ? substr($this->type, $startpos, $endpos - $startpos) : null;
+        $this->nextnextpos = $endpos;
+    }
+
+    /**
+     * Fetch the next token
+     *
+     * @param ?string $expect the expected text
+     * @return non-empty-string
+     */
+    protected function parse_token(?string $expect = null): string {
+
+        $nexttoken = $this->nexttoken;
+
+        // Check we have the expected token.
+        if ($expect != null && $nexttoken != $expect) {
+            throw new \Error("Error parsing type, expected {$expect}, saw {$nexttoken}");
+        } else if ($nexttoken == null) {
+            throw new \Error("Error parsing type, unexpected end");
+        }
+
+        // Prefetch next token.
+        $this->prefetch_next_token();
+
+        // Return consumed token.
+        return $nexttoken;
+    }
+
+    /**
+     * Parse a list of types seperated by | and/or &, or a single nullable type
+     *
+     * @return non-empty-string the simplified type
+     */
+    protected function parse_dnf_type(): string {
+        $uniontypes = [];
+
+        if ($this->nexttoken == '?') {
+            // Parse single nullable type.
+            $this->parse_token('?');
+            array_push($uniontypes, 'void');
+            array_push($uniontypes, $this->parse_single_type());
+        } else {
+            // Parse union list.
+            do {
+                // Parse intersection list.
+                $havebracket = $this->nexttoken == '(';
+                if ($havebracket) {
+                    $this->parse_token('(');
+                }
+                $intersectiontypes = [];
+                do {
+                    array_push($intersectiontypes, $this->parse_single_type());
+                    // We have to figure out whether a & is for intersection or pass by reference.
+                    // Dirty hack.  TODO: Do something better.
+                    $haveintersection = $this->nexttoken == '&'
+                        && ($havebracket || !ctype_space($this->type[$this->nextpos])
+                            || $this->nextnextpos < strlen($this->type) && ctype_space($this->type[$this->nextnextpos]));
+                    if ($haveintersection) {
+                        $this->parse_token('&');
+                    }
+                } while ($haveintersection);
+                if ($havebracket) {
+                    $this->parse_token(')');
+                }
+                // Tidy and store intersection list. TODO: Normalise.
+                if (in_array('callable', $intersectiontypes) && in_array('string', $intersectiontypes)) {
+                    $intersectiontypes[] = 'callable-string';
+                }
+                sort($intersectiontypes);
+                $intersectiontypes = array_unique($intersectiontypes);
+                $neverpos = array_search('never', $intersectiontypes);
+                if ($neverpos !== false) {
+                    $intersectiontypes = ['never'];
+                }
+                $mixedpos = array_search('mixed', $intersectiontypes);
+                if ($mixedpos !== false && count($intersectiontypes) > 1) {
+                    unset($intersectiontypes[$mixedpos]);
+                }
+                array_push($uniontypes, implode('&', $intersectiontypes));
+                // Check for more union items.
+                $haveunion = $this->nexttoken == '|';
+                if ($haveunion) {
+                    $this->parse_token('|');
+                }
+            } while ($haveunion);
+        }
+
+        // Tidy and return union list. TODO: Normalise.
+        sort($uniontypes);
+        $uniontypes = array_unique($uniontypes);
+        $mixedpos = array_search('mixed', $uniontypes);
+        if ($mixedpos !== false) {
+            $uniontypes = ['mixed'];
+        }
+        $neverpos = array_search('never', $uniontypes);
+        if ($neverpos !== false && count($uniontypes) > 1) {
+            unset($uniontypes[$neverpos]);
+        }
+        return implode('|', $uniontypes);
+
+    }
+
+    /**
+     * Parse a single type, possibly array type
+     *
+     * @return non-empty-string the simplified type
+     */
+    protected function parse_single_type(): string {
+
+        // Parse name part.
+        $nextchar = ($this->nexttoken == null) ? null : $this->nexttoken[0];
+        if ($nextchar == '"' || $nextchar == "'" || $nextchar >= '0' && $nextchar <= '9' || $nextchar == '-'
+                || $nextchar == '$' || $nextchar == '\\' || $nextchar != null && ctype_alpha($nextchar) || $nextchar == '_') {
+            $name = $this->parse_token();
+        } else {
+            throw new \Error("Error parsing type, expecting name, saw {$this->nexttoken}");
+        }
+
+        // Parse details part.
+        if ($name == 'bool' || $name == 'boolean' || $name == 'true' || $name == 'false') {
+            // Parse bool details.
+            $name = 'bool';
+        } else if ($name == 'int' || $name == 'integer'
+                || $name == 'positive-int' || $name == 'negative-int'
+                || $name == 'non-positive-int' || $name == 'non-negative-int'
+                || $name == 'non-zero-int'
+                || $name == 'int-mask' || $name == 'int-mask-of'
+                || ($name[0] >= '0' && $name[0] <= '9' || $name[0] == '-') && strpos($name, '.') === false) {
+            // Parse int details.
+            if ($name == 'int' && $this->nexttoken == '<') {
+                // Parse integer range.
+                $this->parse_token('<');
+                $nexttoken = $this->nexttoken;
+                if (!($nexttoken != null && ($nexttoken[0] >= '0' && $nexttoken[0] <= '9' || $nexttoken[0] == '-')
+                        || $nexttoken == 'min')) {
+                    throw new \Error("Error parsing type, expected int min, saw {$nexttoken}");
+                };
+                $this->parse_token();
+                $this->parse_token(',');
+                $nexttoken = $this->nexttoken;
+                if (!($nexttoken != null && ($nexttoken[0] >= '0' && $nexttoken[0] <= '9' || $nexttoken[0] == '-')
+                        || $nexttoken == 'max')) {
+                    throw new \Error("Error parsing type, expected int max, saw {$nexttoken}");
+                };
+                $this->parse_token();
+                $this->parse_token('>');
+            } else if ($name == 'int-mask' || $name == 'int-mask-of') {
+                // Parse integer mask.
+                $this->parse_token('<');
+                $nextchar = ($this->nexttoken != null) ? $this->nexttoken[0] : null;
+                do {
+                    if (!($nextchar != null && ctype_digit($nextchar) && strpos($this->nexttoken, '.') === false)) {
+                        throw new \Error("Error parsing type, expected int mask, saw {$this->nexttoken}");
+                    }
+                    $this->parse_token();
+                    $haveseperator = ($name == 'int-mask') && ($this->nexttoken == ',')
+                                    || ($name == 'int-mask-of') && ($this->nexttoken == '|');
+                    if ($haveseperator) {
+                        $this->parse_token();
+                    }
+                } while ($haveseperator);
+                $this->parse_token('>');
+            }
+            $name = 'int';
+        } else if ($name == 'float' || $name == 'double'
+                || ($name[0] >= '0' && $name[0] <= '9' || $name[0] == '-') && strpos($name, '.') !== false) {
+            // Parse float details.
+            $name = 'float';
+        } else if ($name == 'string' || $name == 'class-string'
+                    || $name == 'numeric-string' || $name == 'non-empty-string'
+                    || $name == 'non-falsy-string' || $name == 'truthy-string'
+                    || $name == 'literal-string'
+                    || $name[0] == '"' || $name[0] == "'") {
+            // Parse string details.
+            if ($name == 'class-string' && $this->nexttoken == '<') {
+                $this->parse_token('<');
+                $classname = $this->parse_single_type();
+                if (!($classname[0] >= 'A' && $classname[0] <= 'Z' || $classname[0] == '_')) {
+                    throw new \Error('Error parsing type, class string type isn\'t class name');
+                }
+                $this->parse_token('>');
+            }
+            $name = 'string';
+        } else if ($name == 'callable-string') {
+            // Parse callable-string details.
+            $name = 'callable-string';
+        } else if ($name == 'array' || $name == 'non-empty-array'
+                    || $name == 'list' || $name == 'non-empty-list') {
+            // Parse array details.
+            if ($this->nexttoken == '<') {
+                // Typed array.
+                $this->parse_token('<');
+                $firsttype = $this->parse_dnf_type();
+                if ($this->nexttoken == ',') {
+                    if ($name == 'list' || $name == 'non-empty-list') {
+                        throw new \Error('Error parsing type, lists cannot have keys specified');
+                    }
+                    $key = $firsttype;
+                    if (!in_array($key, [null, 'int', 'string', 'callable-string', 'array-key'])) {
+                        throw new \Error('Error parsing type, invalid array key');
+                    }
+                    $this->parse_token(',');
+                    $value = $this->parse_dnf_type();
+                } else {
+                    $key = null;
+                    $value = $firsttype;
+                }
+                $this->parse_token('>');
+            } else if ($this->nexttoken == '{') {
+                // Array shape.
+                if ($name == 'list' || $name == 'non-empty-list') {
+                    throw new \Error('Error parsing type, lists cannot have shapes');
+                }
+                $this->parse_token('{');
+                do {
+                    $key = null;
+                    $savednextpos = $this->nextpos;
+                    $savednexttoken = $this->nexttoken;
+                    $savednextnextpos = $this->nextnextpos;
+                    try {
+                        $key = $this->parse_token();
+                        if (!(ctype_alpha($key) || $key[0] == '_' || $key[0] == "'" || $key[0] == '"'
+                                || (ctype_digit($key) || $key[0] == '-') && strpos($key, '.') === false)) {
+                            throw new \Error('Error parsing type, invalid array key');
+                        }
+                        if ($this->nexttoken == '?') {
+                            $this->parse_token('?');
+                        }
+                        $this->parse_token(':');
+                    } catch (\Error $e) {
+                        $this->nextpos = $savednextpos;
+                        $this->nexttoken = $savednexttoken;
+                        $this->nextnextpos = $savednextnextpos;
+                    }
+                    $this->parse_dnf_type();
+                    $havecomma = $this->nexttoken == ',';
+                    if ($havecomma) {
+                        $this->parse_token(',');
+                    }
+                } while ($havecomma);
+                $this->parse_token('}');
+            }
+            $name = 'array';
+        } else if ($name == 'object') {
+            // Parse object details.
+            if ($this->nexttoken == '{') {
+                // Object shape.
+                $this->parse_token('{');
+                do {
+                    $key = $this->parse_token();
+                    if (!(ctype_alpha($key) || $key[0] == '_' || $key[0] == "'" || $key[0] == '"')) {
+                        throw new \Error('Error parsing type, invalid array key');
+                    }
+                    if ($this->nexttoken == '?') {
+                        $this->parse_token('?');
+                    }
+                    $this->parse_token(':');
+                    $this->parse_dnf_type();
+                    $havecomma = $this->nexttoken == ',';
+                    if ($havecomma) {
+                        $this->parse_token(',');
+                    }
+                } while ($havecomma);
+                $this->parse_token('}');
+            }
+            $name = 'object';
+        } else if ($name == 'resource') {
+            // Parse resource details.
+            $name = 'resource';
+        } else if ($name == 'never' || $name == 'never-return' || $name == 'never-returns' || $name == 'no-return') {
+            // Parse never details.
+            $name = 'never';
+        } else if ($name == 'void' || $name == 'null') {
+            // Parse void details.
+            $name = 'void';
+        } else if ($name == 'self') {
+            // Parse self details.
+            $name = 'self';
+        } else if ($name == 'parent') {
+            // Parse parent details.
+            $name = 'parent';
+        } else if ($name == 'static' || $name == '$this') {
+            // Parse static details.
+            $name = 'static';
+        } else if ($name == 'callable') {
+            // Parse callable details.
+            if ($this->nexttoken == '(') {
+                $this->parse_token('(');
+                $splat = false;
+                while ($this->nexttoken != ')') {
+                    $this->parse_dnf_type();
+                    if ($this->nexttoken == '=') {
+                        $this->parse_token('=');
+                    }
+                    if ($this->nexttoken == '...') {
+                        $this->parse_token('...');
+                        $splat = true;
+                    }
+                    $nextchar = ($this->nexttoken != null) ? $this->nexttoken[0] : null;
+                    if ($nextchar == '&' || $nextchar == '$') {
+                        if ($this->nexttoken == '&') {
+                            if ($splat) {
+                                throw new \Error("Error parsing type, can't pass splat by reference");
+                            }
+                            $this->parse_token('&');
+                        }
+                        $nextchar = ($this->nexttoken != null) ? $this->nexttoken[0] : null;
+                        if ($nextchar == '$') {
+                            $this->parse_token();
+                        } else {
+                            throw new \Error("Error parsing type, expected var name, saw {$this->nexttoken}");
+                        }
+                    }
+                    if ($this->nexttoken != ')') {
+                        if ($splat) {
+                            throw new \Error("Error parsing type, expected end of param list, saw {$this->nexttoken}");
+                        }
+                        $this->parse_token(',');
+                    }
+                };
+                $this->parse_token(')');
+                $this->parse_token(':');
+                if ($this->nexttoken == '(') {
+                    $this->parse_token('(');
+                    $this->parse_dnf_type();
+                    $this->parse_token(')');
+                } else {
+                    if ($this->nexttoken == '?') {
+                        $this->parse_token('?');
+                    }
+                    $this->parse_single_type();
+                }
+            }
+            $name = 'callable';
+        } else if ($name == 'mixed') {
+            // Parse mixed details.
+            $name = 'mixed';
+        } else if ($name == 'iterable') {
+            // Parse iterable details (Traversable|array).
+            if ($this->nexttoken == '<') {
+                $this->parse_token('<');
+                $this->parse_dnf_type();
+                $this->parse_token('>');
+            }
+            $name = 'iterable';
+        } else if ($name == 'array-key') {
+            // Parse array-key details (int|string).
+            $name = 'array-key';
+        } else if ($name == 'scalar') {
+            // Parse scalar details (bool|int|float|string).
+            $name = 'scalar';
+        } else if ($name == 'key-of') {
+            // Parse key-of details.
+            $this->parse_token('<');
+            $this->parse_single_type();
+            $this->parse_token('>');
+            $name = 'array-key';
+        } else if ($name == 'value-of') {
+            // Parse value-of details.
+            $this->parse_token('<');
+            $this->parse_single_type();
+            $this->parse_token('>');
+            $name = 'mixed';
+        } else {
+            // Check valid class name.
+            if (strpos($name, '$') !== false || strpos($name, '-') !== false || strpos($name, '\\\\') !== false) {
+                throw new \Error('Error parsing type, invalid class name');
+            }
+            $lastseperatorpos = strrpos($name, '\\');
+            if ($lastseperatorpos !== false) {
+                $name = substr($name, $lastseperatorpos + 1);
+            }
+            if ($name == '') {
+                throw new \Error('Error parsing type, class name has trailing slash');
+            }
+            $name = ucfirst($name);
+        }
+        // TODO: Conditional return types.
+
+        // Parse array suffix.
+        $arrayed = ($this->nexttoken == '[');
+        if ($arrayed) {
+            $this->parse_token('[');
+            $this->parse_token(']');
+        }
+
+        return $arrayed ? 'array' : $name;
+    }
+
+}

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -265,14 +265,14 @@ class type_parser {
                     $havepoint = $havepoint || $nextchar == '.';
                     $endpos = $endpos + 1;
                     $nextchar = ($endpos < strlen($this->text)) ? $this->text[$endpos] : null;
-                } while ($nextchar != null && (ctype_digit($nextchar) || $nextchar == '.' && !$havepoint));
+                } while ($nextchar != null && (ctype_digit($nextchar) || $nextchar == '.' && !$havepoint || $nextchar == '_'));
             } else if ($firstchar == '"' || $firstchar == '\'') {
                 // String token.
                 $endpos = $startpos + 1;
                 $nextchar = ($endpos < strlen($this->text)) ? $this->text[$endpos] : null;
                 while ($nextchar != $firstchar && $nextchar != null) { // There may be unterminated strings.
                     if ($nextchar == '\\' && strlen($this->text) >= $endpos + 2) {
-                            $endpos = $endpos + 2;
+                        $endpos = $endpos + 2;
                     } else {
                         $endpos++;
                     }

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -196,11 +196,15 @@ class type_parser {
      * @return non-empty-string[] super types
      */
     protected static function super_types(string $basetype): array {
-        if (in_array($basetype, ['int', 'string'])) {
+        if ($basetype == 'int') {
+            $supertypes = ['array-key', 'number', 'scaler'];
+        } else if ($basetype == 'string') {
             $supertypes = ['array-key', 'scaler'];
         } else if ($basetype == 'callable-string') {
             $supertypes = ['callable', 'string', 'array-key', 'scalar'];
-        } else if (in_array($basetype, ['array-key', 'bool', 'float'])) {
+        } else if ($basetype == 'float') {
+            $supertypes = ['number', 'scalar'];
+        } else if (in_array($basetype, ['array-key', 'number', 'bool'])) {
             $supertypes = ['scalar'];
         } else if ($basetype == 'array') {
             $supertypes = ['iterable'];
@@ -421,10 +425,13 @@ class type_parser {
         }
 
         // Tidy and return union list.
-        if (in_array('int', $uniontypes) && in_array('string', $uniontypes)) {
+        if ((in_array('int', $uniontypes) || in_array('number', $uniontypes)) && in_array('string', $uniontypes)) {
             $uniontypes[] = 'array-key';
         }
-        if (in_array('array-key', $uniontypes) && in_array('bool', $uniontypes) && in_array('float', $uniontypes)) {
+        if ((in_array('int', $uniontypes) || in_array('array-key', $uniontypes)) && in_array('float', $uniontypes)) {
+            $uniontypes[] = 'number';
+        }
+        if (in_array('bool', $uniontypes) && in_array('number', $uniontypes) && in_array('array-key', $uniontypes)) {
             $uniontypes[] = 'scalar';
         }
         if (in_array('Traversable', $uniontypes) && in_array('array', $uniontypes)) {
@@ -703,6 +710,10 @@ class type_parser {
             // Array-key (int|string).
             $this->parse_token('array-key');
             $type = 'array-key';
+        } else if ($next == 'number') {
+            // Number (int|float).
+            $this->parse_token('number');
+            $type = 'number';
         } else if ($next == 'scalar') {
             // Scalar can be (bool|int|float|string).
             $this->parse_token('scalar');

--- a/classes/type_parser.php
+++ b/classes/type_parser.php
@@ -60,7 +60,8 @@ class type_parser {
         $savednextnextpos = $this->nextnextpos;
         try {
             $outtype = $this->parse_dnf_type();
-            if ($this->nextpos < strlen($intype) && !ctype_space($intype[$this->nextpos]) && $this->nexttoken != '...') {
+            if ($this->nextpos < strlen($intype) && !ctype_space($intype[$this->nextpos])
+                && !($this->nexttoken == '&' || $this->nexttoken == '...')) {
                 throw new \Error("Error parsing type, no space at end of type");
             }
         } catch (\Error $e) {
@@ -303,9 +304,9 @@ class type_parser {
                     array_push($intersectiontypes, $this->parse_single_type());
                     // We have to figure out whether a & is for intersection or pass by reference.
                     // Dirty hack.  TODO: Do something better.
-                    $haveintersection = $this->nexttoken == '&'
-                        && ($havebracket || !ctype_space($this->type[$this->nextpos])
-                            || $this->nextnextpos < strlen($this->type) && ctype_space($this->type[$this->nextnextpos]));
+                    $haveintersection = $this->nexttoken == '&' && ($this->nextnextpos < strlen($this->type))
+                        && ($havebracket || !(ctype_space($this->type[$this->nextpos])
+                                            xor ctype_space($this->type[$this->nextnextpos])));
                     if ($haveintersection) {
                         $this->parse_token('&');
                     }

--- a/file.php
+++ b/file.php
@@ -212,14 +212,20 @@ class local_moodlecheck_file {
                 $after = T_USE;
                 $classname = null;
                 $alias = null;
-            } else if ($after == T_USE && $tokens[$tid][0] == T_STRING) {
+            } else if ($after == T_USE
+                    && ($tokens[$tid][0] == T_STRING
+                        || PHP_VERSION_ID >= 80000
+                            && in_array($tokens[$tid][0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))) {
                 $classname = $tokens[$tid][1];
                 if (strrpos($classname, '\\') !== false) {
                     $classname = substr($classname, strrpos($classname, '\\') + 1);
                 }
             } else if ($after == T_USE && $tokens[$tid][0] == T_AS) {
                 $after = T_AS;
-            } else if ($after == T_AS && $tokens[$tid][0] == T_STRING) {
+            } else if ($after == T_AS
+                    && ($tokens[$tid][0] == T_STRING
+                        || PHP_VERSION_ID >= 80000
+                            && in_array($tokens[$tid][0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))) {
                 $alias = $tokens[$tid][1];
             } else if (($after == T_USE || $after == T_AS) && in_array($tokens[$tid][1], [',', ';'])) {
                 if ($after == T_AS && $classname && $alias) {
@@ -332,14 +338,19 @@ class local_moodlecheck_file {
                         // Iterate over the remaining tokens in the class definition (until opening {).
                         foreach (array_slice($this->tokens, $tid, $artifact->tagpair[0] - $tid) as $token) {
                             if ($after == T_IMPLEMENTS && $implements
-                                    && !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_NS_SEPARATOR, T_STRING])) {
+                                    && !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_NS_SEPARATOR, T_STRING])
+                                    && !(PHP_VERSION_ID >= 80000
+                                        && in_array($token[0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))) {
                                 $artifact->implements[] = $implements;
                                 $implements = null;
                             }
                             if ($token[0] == T_EXTENDS) {
                                 $artifact->hasextends = true;
                                 $after = T_EXTENDS;
-                            } else if ($after == T_EXTENDS && $token[0] == T_STRING) {
+                            } else if ($after == T_EXTENDS
+                                    && ($token[0] == T_STRING
+                                        || PHP_VERSION_ID >= 80000
+                                            && in_array($token[0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))) {
                                 $extends = $token[1];
                                 if (strrpos($extends, '\\') !== false) {
                                     $extends = substr($extends, strrpos($extends, '\\') + 1);
@@ -349,12 +360,17 @@ class local_moodlecheck_file {
                                 $artifact->hasimplements = true;
                                 $after = T_IMPLEMENTS;
                                 $implements = null;
-                            } else if ($after == T_IMPLEMENTS && $token[0] == T_STRING) {
+                            } else if ($after == T_IMPLEMENTS
+                                    && ($token[0] == T_STRING
+                                        || PHP_VERSION_ID >= 80000
+                                            && in_array($token[0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))) {
                                 $implements = $token[1];
                                 if (strrpos($implements, '\\') !== false) {
                                     $implements = substr($implements, strrpos($implements, '\\') + 1);
                                 }
                             } else if (!in_array($token[0], [T_WHITESPACE, T_COMMENT, T_NS_SEPARATOR, T_STRING])
+                                    && !(PHP_VERSION_ID >= 80000
+                                        && in_array($token[0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED, T_NAME_RELATIVE]))
                                     && $token[1] !== ',') {
                                 $after = null;
                             }

--- a/file.php
+++ b/file.php
@@ -1237,7 +1237,7 @@ class local_moodlecheck_phpdocs {
         'static',
         'staticvar',
         'subpackage',
-        // Maybe add: 'template',
+        // Maybe add: 'template', .
         'throws',
         'todo',
         'tutorial',
@@ -1284,7 +1284,7 @@ class local_moodlecheck_phpdocs {
         'see',
         'since',
         'subpackage',
-        // Maybe add: 'template',
+        // Maybe add: 'template', .
         'throws',
         'todo',
         'uses',

--- a/file.php
+++ b/file.php
@@ -402,11 +402,13 @@ class local_moodlecheck_file {
                         // Get type and variable.
                         $text = '';
                         for (; $j < count($argtokens); $j++) {
-                            $text .= $argtokens[$j][1];
+                            if ($argtokens[$j][0] != T_COMMENT) {
+                                $text .= $argtokens[$j][1];
+                            }
                         }
-                        list($type, $variable, $default) = $typeparser->parse_type_and_var($text);
+                        list($type, $variable, $default, $nullable) = $typeparser->parse_type_and_var($text, 3, true);
 
-                        $function->arguments[] = array($type, $variable);
+                        $function->arguments[] = array($type, $variable, $nullable);
                     }
                     $function->boundaries = $this->find_object_boundaries($function);
                     $this->functions[] = $function;
@@ -1329,19 +1331,19 @@ class local_moodlecheck_phpdocs {
      *
      * Each element is array(typename, variablename, variabledescription)
      *
-     * @param string $tag tag name to look for. Usually param but may be var for variables
-     * @param bool $getvar whether to get variable name
+     * @param string $tag tag name to look for. Usually 'param' but may be 'var' for variables
+     * @param 0|1|2|3 $getwhat what to get 0=type only 1=also var 2=also modifiers (& ...) 3=also default
      * @return array
      */
-    public function get_params($tag = 'param', $getvar = true) {
+    public function get_params(string $tag, int $getwhat) {
         $typeparser = new \local_moodlecheck\type_parser();
         $params = array();
 
         foreach ($this->get_tags($tag) as $token) {
-            list($type, $variable, $description) = $typeparser->parse_type_and_var($token, $getvar);
+            list($type, $variable, $description) = $typeparser->parse_type_and_var($token, $getwhat, false);
             $param = [];
             $param[] = $type;
-            if ($getvar) {
+            if ($getwhat >= 1) {
                 $param[] = $variable;
             }
             $param[] = $description;

--- a/file.php
+++ b/file.php
@@ -1237,7 +1237,7 @@ class local_moodlecheck_phpdocs {
         'static',
         'staticvar',
         'subpackage',
-        // 'template',
+        // Maybe add: 'template',
         'throws',
         'todo',
         'tutorial',
@@ -1284,7 +1284,7 @@ class local_moodlecheck_phpdocs {
         'see',
         'since',
         'subpackage',
-        // 'template',
+        // Maybe add: 'template',
         'throws',
         'todo',
         'uses',
@@ -1498,12 +1498,12 @@ class local_moodlecheck_phpdocs {
                 }
                 $type = 'mixed';
                 if (substr($token, $ofstart, 2) == 'of') {
-                    list($type) = $typeparser->parse_type_and_var(null, substr($token, $ofstart+2), 0, false);
+                    list($type) = $typeparser->parse_type_and_var(null, substr($token, $ofstart + 2), 0, false);
                 }
                 $templates[strtolower(substr($token, 0, $nameend))] = $type;
             }
         }
-        
+
         return $templates;
     }
 

--- a/file.php
+++ b/file.php
@@ -399,14 +399,14 @@ class local_moodlecheck_file {
                             $j++;
                         }
 
-                        // Get type, variable name, and default value.
+                        // Get type and variable.
                         $text = '';
                         for (; $j < count($argtokens); $j++) {
                             $text .= $argtokens[$j][1];
                         }
                         list($type, $variable, $default) = $typeparser->parse_type_and_var($text);
 
-                        $function->arguments[] = array($type, $variable, $default);
+                        $function->arguments[] = array($type, $variable);
                     }
                     $function->boundaries = $this->find_object_boundaries($function);
                     $this->functions[] = $function;

--- a/file.php
+++ b/file.php
@@ -503,7 +503,7 @@ class local_moodlecheck_file {
                         }
                         list($type, $variable, $default, $nullable) = $typeparser->parse_type_and_var($text, 3, true);
 
-                        $function->arguments[] = array($type, $variable, $nullable);
+                        $function->arguments[] = [$type, $variable, $nullable];
                     }
 
                     // Get return type.

--- a/file.php
+++ b/file.php
@@ -399,14 +399,14 @@ class local_moodlecheck_file {
                             $j++;
                         }
 
-                        // Get type and variable.
+                        // Get type, variable name, and default value.
                         $text = '';
                         for (; $j < count($argtokens); $j++) {
                             $text .= $argtokens[$j][1];
                         }
                         list($type, $variable, $default) = $typeparser->parse_type_and_var($text);
 
-                        $function->arguments[] = array($type, $variable);
+                        $function->arguments[] = array($type, $variable, $default);
                     }
                     $function->boundaries = $this->find_object_boundaries($function);
                     $this->functions[] = $function;

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -427,7 +427,8 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
             $documentedarguments = $function->phpdocs->get_params('param', 2);
             $match = (count($documentedarguments) == count($function->arguments));
             for ($i = 0; $match && $i < count($documentedarguments); $i++) {
-                if (count($documentedarguments[$i]) < 2 || $documentedarguments[$i][0] == null || $documentedarguments[$i][1] == null) {
+                if (count($documentedarguments[$i]) < 2 || $documentedarguments[$i][0] == null
+                        || $documentedarguments[$i][1] == null) {
                     // Must be at least type and parameter name.
                     $match = false;
                 } else {

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -424,25 +424,28 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
 
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs !== false) {
-            $documentedarguments = $function->phpdocs->get_params();
+            $documentedarguments = $function->phpdocs->get_params('param', 2);
             $match = (count($documentedarguments) == count($function->arguments));
             for ($i = 0; $match && $i < count($documentedarguments); $i++) {
-                if (count($documentedarguments[$i]) < 2 || $documentedarguments[$i][0] == null) {
+                if (count($documentedarguments[$i]) < 2 || $documentedarguments[$i][0] == null || $documentedarguments[$i][1] == null) {
                     // Must be at least type and parameter name.
                     $match = false;
                 } else {
                     $expectedtype = $function->arguments[$i][0];
                     $expectedparam = (string)$function->arguments[$i][1];
+                    $expectednullable = $function->arguments[$i][2];
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
 
                     $match = ($expectedparam === $documentedparam)
-                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype);
+                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype)
+                            // Code smell check follows.
+                            && (!$expectednullable || strpos("|{$documentedtype}|", "|void|") !== false);
                 }
             }
-            $documentedreturns = $function->phpdocs->get_params('return', false);
+            $documentedreturns = $function->phpdocs->get_params('return', 0);
             for ($i = 0; $match && $i < count($documentedreturns); $i++) {
-                if (empty($documentedreturns[$i][0]) || $documentedreturns[$i][0] == 'type') {
+                if (empty($documentedreturns[$i][0])) {
                     $match = false;
                 }
             }
@@ -464,7 +467,7 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_normalise_function_type(string $typelist): ?string {
     $typeparser = new \local_moodlecheck\type_parser();
-    list($type, $variable, $remainder) = $typeparser->parse_type_and_var($typelist, false);
+    list($type, $variable, $remainder) = $typeparser->parse_type_and_var($typelist, 0, true);
     return $type;
 }
 
@@ -478,8 +481,8 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
     $errors = array();
     foreach ($file->get_variables() as $variable) {
         if ($variable->phpdocs !== false) {
-            $documentedvars = $variable->phpdocs->get_params('var', false);
-            if (!count($documentedvars) || $documentedvars[0][0] == 'type' || $documentedvars[0][0] == null) {
+            $documentedvars = $variable->phpdocs->get_params('var', 0);
+            if (!count($documentedvars) || $documentedvars[0][0] == null) {
                 $errors[] = array(
                     'line' => $variable->phpdocs->get_line_number($file, '@var'),
                     'variable' => $variable->fullname);

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -503,7 +503,7 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_normalise_function_type(string $typelist): ?string {
     $typeparser = new \local_moodlecheck\type_parser();
-    list($type, $variable, $remainder) = $typeparser->parse_type_and_var($typelist, 0, true);
+    list($type, $variable, $remainder) = $typeparser->parse_type_and_var(null, $typelist, 0, true);
     return $type;
 }
 

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -482,9 +482,9 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
             }
 
             if ($errorlevel > 0) {
-                $error = array(
+                $error = [
                     'line' => $function->phpdocs->get_line_number($file, '@param'),
-                    'function' => $function->fullname);
+                    'function' => $function->fullname,];
                 if ($errorlevel < 2) {
                     $error['severity'] = 'warning';
                 }
@@ -540,9 +540,9 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
             }
 
             if ($errorlevel > 0) {
-                $error = array(
+                $error = [
                     'line' => $variable->phpdocs->get_line_number($file, '@var'),
-                    'variable' => $variable->fullname);
+                    'variable' => $variable->fullname,];
                 if ($errorlevel < 2) {
                     $error['severity'] = 'warning';
                 }

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -484,7 +484,7 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
             if ($errorlevel > 0) {
                 $error = [
                     'line' => $function->phpdocs->get_line_number($file, '@param'),
-                    'function' => $function->fullname,];
+                    'function' => $function->fullname, ];
                 if ($errorlevel < 2) {
                     $error['severity'] = 'warning';
                 }
@@ -542,7 +542,7 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
             if ($errorlevel > 0) {
                 $error = [
                     'line' => $variable->phpdocs->get_line_number($file, '@var'),
-                    'variable' => $variable->fullname,];
+                    'variable' => $variable->fullname, ];
                 if ($errorlevel < 2) {
                     $error['severity'] = 'warning';
                 }

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -440,7 +440,7 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                             && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype);
                 }
             }
-            $documentedreturns = $function->phpdocs->get_params('return');
+            $documentedreturns = $function->phpdocs->get_params('return', false);
             for ($i = 0; $match && $i < count($documentedreturns); $i++) {
                 if (empty($documentedreturns[$i][0]) || $documentedreturns[$i][0] == 'type') {
                     $match = false;
@@ -464,7 +464,7 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_normalise_function_type(string $typelist): ?string {
     $typeparser = new \local_moodlecheck\type_parser();
-    list($type, $remainder) = $typeparser->parse_type($typelist);
+    list($type, $variable, $remainder) = $typeparser->parse_type_and_var($typelist, false);
     return $type;
 }
 
@@ -478,7 +478,7 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
     $errors = array();
     foreach ($file->get_variables() as $variable) {
         if ($variable->phpdocs !== false) {
-            $documentedvars = $variable->phpdocs->get_params('var', 2);
+            $documentedvars = $variable->phpdocs->get_params('var', false);
             if (!count($documentedvars) || $documentedvars[0][0] == 'type' || $documentedvars[0][0] == null) {
                 $errors[] = array(
                     'line' => $variable->phpdocs->get_line_number($file, '@var'),

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -515,7 +515,7 @@ function local_moodlecheck_normalise_function_type(string $typelist): ?string {
  */
 function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
     $typeparser = $file->get_type_parser();
-    $errors = array();
+    $errors = [];
     foreach ($file->get_variables() as $variable) {
         if ($variable->phpdocs !== false) {
             $ownername = $variable->class ? $variable->class->name : null;

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -433,11 +433,15 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                 } else {
                     $expectedtype = $function->arguments[$i][0];
                     $expectedparam = (string)$function->arguments[$i][1];
+                    $expecteddefault = $function->arguments[$i][2];
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
 
                     $match = ($expectedparam === $documentedparam)
-                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype);
+                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype)
+                            && !($expecteddefault == 'null'
+                                && strpos("|{$documentedtype}|", '|void|') === false
+                                && $documentedtype != 'mixed');
                 }
             }
             $documentedreturns = $function->phpdocs->get_params('return', false);

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -433,15 +433,11 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                 } else {
                     $expectedtype = $function->arguments[$i][0];
                     $expectedparam = (string)$function->arguments[$i][1];
-                    $expecteddefault = $function->arguments[$i][2];
                     $documentedtype = $documentedarguments[$i][0];
                     $documentedparam = $documentedarguments[$i][1];
 
                     $match = ($expectedparam === $documentedparam)
-                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype)
-                            && !($expecteddefault == 'null'
-                                && strpos("|{$documentedtype}|", '|void|') === false
-                                && $documentedtype != 'mixed');
+                            && \local_moodlecheck\type_parser::compare_types($expectedtype, $documentedtype);
                 }
             }
             $documentedreturns = $function->phpdocs->get_params('return', false);

--- a/tests/fixtures/phpdoc_tags_general.php
+++ b/tests/fixtures/phpdoc_tags_general.php
@@ -254,7 +254,7 @@ class fixturing_general {
      */
     public function builtin(
         ?\stdClass $data,
-        ?\core\test\something|\core\some\other_thing $moredata
+        \core\test\something|\core\some\other_thing|null $moredata
     ): \stdClass {
         return $user;
     }

--- a/tests/fixtures/phpdoc_types_invalid.php
+++ b/tests/fixtures/phpdoc_types_invalid.php
@@ -1,0 +1,96 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:ignoreFile
+
+/**
+ * A collection of invalid types for testing
+ *
+ * All these should fail type checking.
+ * Having just invalid types in here means the number of errors should match the number of type annotations.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Te Pūkenga – New Zealand Institute of Skills and Technology
+ * @author    James Calder
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (or CC BY-SA v4 or later)
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+/**
+ * A collection of invalid types for testing
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Te Pūkenga – New Zealand Institute of Skills and Technology
+ * @author    James Calder
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (or CC BY-SA v4 or later)
+ */
+class types_invalid {
+
+    /**
+     * Expecting variable name, saw end
+     * @param int
+     */
+    public function expecting_var_saw_end(int $x): void {
+    }
+
+    /**
+     * Expecting variable name, saw other
+     * @param int int
+     */
+    public function expecting_var_saw_other(int $x): void {
+    }
+
+    // Expecting type, saw end.
+    /** @var */
+    public $expectingtypesawend;
+
+    /** @var $varname Expecting type, saw other */
+    public $expectingtypesawother;
+
+    // Expecting class for class-string, saw end.
+    /** @var class-string< */
+    public $expectingclassforclassstringsawend;
+
+    /** @var class-string<int> Expecting class for class-string, saw other */
+    public $expectingclassforclassstringsawother;
+
+    /** @var list<int, string> List key */
+    public $listkey;
+
+    /** @var non-empty-array{'a': int} Non-empty-array shape */
+    public $nonemptyarrayshape;
+
+    /** @var object{0.0: int} Invalid object key */
+    public $invalidobjectkey;
+
+    /**
+     * Class name has trailing slash
+     * @param types_invalid/ $x
+     */
+    public function class_name_has_trailing_slash(object $x): void {
+    }
+
+    // Expecting closing bracket, saw end.
+    /** @var (types_invalid */
+    public $expectingclosingbracketsawend;
+
+    /** @var (types_invalid int Expecting closing bracket, saw other*/
+    public $expectingclosingbracketsawother;
+
+}

--- a/tests/fixtures/phpdoc_types_invalid.php
+++ b/tests/fixtures/phpdoc_types_invalid.php
@@ -63,6 +63,18 @@ class types_invalid {
     /** @var $varname Expecting type, saw other */
     public $expectingtypesawother;
 
+    // Unterminated string.
+    /** @var " */
+    public $unterminatedstring;
+
+    // Unterminated string with escaped quote.
+    /** @var "\"*/
+    public $unterminatedstringwithescapedquote;
+
+    // String has escape with no following character.
+    /** @var "\*/
+    public $stringhasescapewithnofollowingchar;
+
     // Expecting class for class-string, saw end.
     /** @var class-string< */
     public $expectingclassforclassstringsawend;

--- a/tests/fixtures/phpdoc_types_invalid.php
+++ b/tests/fixtures/phpdoc_types_invalid.php
@@ -19,7 +19,7 @@
 /**
  * A collection of invalid types for testing
  *
- * All these should fail type checking.
+ * Every type annotation should give an error either when checked with PHPStan or Psalm.
  * Having just invalid types in here means the number of errors should match the number of type annotations.
  *
  * @package   local_moodlecheck
@@ -29,8 +29,6 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
 
 /**
  * A collection of invalid types for testing
@@ -50,7 +48,7 @@ class types_invalid {
     }
 
     /**
-     * Expecting variable name, saw other
+     * Expecting variable name, saw other (passes Psalm)
      * @param int int
      */
     public function expecting_var_saw_other(int $x): void {
@@ -63,17 +61,35 @@ class types_invalid {
     /** @var $varname Expecting type, saw other */
     public $expectingtypesawother;
 
-    // Unterminated string.
+    // Unterminated string (passes Psalm).
     /** @var " */
     public $unterminatedstring;
 
-    // Unterminated string with escaped quote.
+    // Unterminated string with escaped quote (passes Psalm).
     /** @var "\"*/
     public $unterminatedstringwithescapedquote;
 
-    // String has escape with no following character.
+    // String has escape with no following character (passes Psalm).
     /** @var "\*/
     public $stringhasescapewithnofollowingchar;
+
+    /** @var array-key&(int|string) Non-DNF type (passes PHPStan) */
+    public $nondnftype;
+
+    /** @var int&string Invalid intersection */
+    public $invalidintersection;
+
+    /** @var int<0.0, 1> Invalid int min */
+    public $invalidintmin;
+
+    /** @var int<0, 1.0> Invalid int max */
+    public $invalidintmax;
+
+    /** @var int-mask<1.0, 2.0> Invalid int mask 1 */
+    public $invalidintmask1;
+
+    /** @var int-mask-of<string> Invalid int mask 2 */
+    public $invalidintmask2;
 
     // Expecting class for class-string, saw end.
     /** @var class-string< */
@@ -85,11 +101,20 @@ class types_invalid {
     /** @var list<int, string> List key */
     public $listkey;
 
+    /** @var array<object, object> Invalid array key (passes Psalm) */
+    public $invalidarraykey;
+
     /** @var non-empty-array{'a': int} Non-empty-array shape */
     public $nonemptyarrayshape;
 
-    /** @var object{0.0: int} Invalid object key */
+    /** @var object{0.0: int} Invalid object key (passes Psalm) */
     public $invalidobjectkey;
+
+    /** @var key-of<int> Can't get key of non-iterable */
+    public $cantgetkeyofnoniterable;
+
+    /** @var value-of<int> Can't get value of non-iterable */
+    public $cantgetvalueofnoniterable;
 
     /**
      * Class name has trailing slash

--- a/tests/fixtures/phpdoc_types_valid.php
+++ b/tests/fixtures/phpdoc_types_valid.php
@@ -109,7 +109,7 @@ class types_valid extends types_valid_parent {
      * @return never
      */
     public function non_native_types($parameterisedarray, $resource, $static, $parameterisediterable,
-            $arraykey, $scalar, $mixed): void {
+            $arraykey, $scalar, $mixed) {
         throw new \Exception();
     }
 
@@ -222,21 +222,21 @@ class types_valid extends types_valid_parent {
      * Never type
      * @return never|never-return|never-returns|no-return
      */
-    public function never_type(): void {
+    public function never_type() {
         throw new \Exception();
     }
 
     /**
      * Void type
+     * @param null $standalonenull
      * @param ?int $explicitnullable
      * @param ?int $implicitnullable
-     * @param null $standalonenull
      * @return void
      */
     public function void_type(
+        $standalonenull,
         ?int $explicitnullable,
-        int $implicitnullable=null,
-        $standalonenull
+        int $implicitnullable=null
     ): void {
     }
 
@@ -285,7 +285,7 @@ class types_valid extends types_valid_parent {
     }
 
     /**
-     * Key and valud of complex
+     * Key and value of complex
      * @param key-of<types_valid::ARRAY_CONST|array<int, string>> $keyof2
      * @param value-of<types_valid::ARRAY_CONST|array<int, string>> $valueof2
      */
@@ -386,6 +386,47 @@ class types_valid extends types_valid_parent {
         array $bracketarray1,
         array $bracketarray2,
         $dnf
+    ): void {
+    }
+
+    /**
+     * Inheritance
+     * @param types_valid $basic
+     * @param self|static|$this $relative1
+     * @param types_valid $relative2
+     */
+    public function inheritance(
+        types_valid_parent $basic,
+        parent $relative1,
+        parent $relative2
+    ): void {
+    }
+
+    /**
+     * Built-in classes
+     * @param Traversable<string>|Iterator|Generator|IteratorAggregate $traversable
+     * @param Iterator|Generator $iterator
+     * @param Throwable|Exception|Error $throwable
+     * @param Exception|ErrorException $exception
+     * @param Error|ArithmeticError|AssertionError|ParseError|TypeError $error
+     * @param ArithmeticError|DivisionByZeroError $arithmeticerror
+     * @param CompileError|ParseError $compileerror
+     */
+    public function builtin_classes(
+        Traversable $traversable, Iterator $iterator,
+        Throwable $throwable, Exception $exception, Error $error,
+        ArithmeticError $arithmeticerror, CompileError $compileerror
+    ): void {
+    }
+
+    /**
+     * SPL classes
+     * @param Iterator|SeekableIterator<int, string>|ArrayIterator $iterator
+     * @param SeekableIterator<int, string>|ArrayIterator $seekableiterator
+     * @param Countable|ArrayIterator $countable
+     */
+    public function spl_classes(
+        Iterator $iterator, SeekableIterator $seekableiterator, Countable $countable
     ): void {
     }
 

--- a/tests/fixtures/phpdoc_types_valid.php
+++ b/tests/fixtures/phpdoc_types_valid.php
@@ -138,20 +138,21 @@ class types_valid extends types_valid_parent {
      * @param int|integer $int
      * @param positive-int|negative-int|non-positive-int|non-negative-int|non-zero-int $intrange1
      * @param int<0, 100>|int<min, 100>|int<50, max>|int<-100, max> $intrange2
-     * @param 234|-234 $literal
+     * @param 234|-234 $literal1
      * @param int-mask<1, 2, 4>|int-mask-of<1|2|4> $intmask1
      */
     public function integer_types(int $int, int $intrange1, int $intrange2,
-        int $literal, int $intmask1): void {
+        int $literal1, int $intmask1): void {
     }
 
     /**
      * Integer types complex
      * @param int<types_valid::INT_ONE, types_valid::INT_TWO> $intrange3
+     * @param 1_000|-1_000 $literal2
      * @param int-mask<types_valid::INT_*>|int-mask<key-of<types_valid::ARRAY_CONST>> $intmask2
      * @param int-mask-of<types_valid::INT_*>|int-mask-of<key-of<types_valid::ARRAY_CONST>> $intmask3
      */
-    public function integer_types_complex(int $intrange3, int $intmask2, int $intmask3): void {
+    public function integer_types_complex(int $intrange3, int $literal2, int $intmask2, int $intmask3): void {
     }
 
     /**

--- a/tests/fixtures/phpdoc_types_valid.php
+++ b/tests/fixtures/phpdoc_types_valid.php
@@ -1,0 +1,398 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A collection of valid types for testing
+ *
+ * These should pass all relevant code checks.
+ * Having just valid code in here means it can be checked with another checker, such as PHPStan,
+ * to verify we are actually checking against correct examples.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Te Pūkenga – New Zealand Institute of Skills and Technology
+ * @author    James Calder
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (or CC BY-SA v4 or later)
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+/**
+ * A parent class
+ */
+class types_valid_parent {
+}
+
+/**
+ * An interface
+ */
+interface types_valid_interface {
+}
+
+/**
+ * A collection of valid types for testing
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Te Pūkenga – New Zealand Institute of Skills and Technology
+ * @author    James Calder
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (or CC BY-SA v4 or later)
+ */
+class types_valid extends types_valid_parent {
+
+    /** @var array<int, string> */
+    public const ARRAY_CONST = [ 1 => 'one', 2 => 'two' ];
+    /** @var int */
+    public const INT_ONE = 1;
+    /** @var int */
+    public const INT_TWO = 2;
+    /** @var float */
+    public const FLOAT_1_0 = 1.0;
+    /** @var float */
+    public const FLOAT_2_0 = 2.0;
+    /** @var string */
+    public const STRING_HELLO = "Hello";
+    /** @var string */
+    public const STRING_WORLD = "World";
+    /** @var bool */
+    public const BOOL_FALSE = false;
+    /** @var bool */
+    public const BOOL_TRUE = true;
+
+
+    /**
+     * Basic type equivalence
+     * @param bool $bool
+     * @param int $int
+     * @param float $float
+     * @param string $string
+     * @param object $object
+     * @param self $self
+     * @param parent $parent
+     * @param types_valid $specificclass
+     * @param callable $callable
+     * @return void
+     */
+    public function basic_type_equivalence(
+        bool $bool,
+        int $int,
+        float $float,
+        string $string,
+        object $object,
+        self $self,
+        parent $parent,
+        types_valid $specificclass,
+        callable $callable
+    ): void {
+    }
+
+    /**
+     * Types not supported natively (as of PHP 7.2)
+     * @param array<int> $parameterisedarray
+     * @param resource $resource
+     * @param static $static
+     * @param iterable<int> $parameterisediterable
+     * @param array-key $arraykey
+     * @param scalar $scalar
+     * @param mixed $mixed
+     * @return never
+     */
+    public function non_native_types($parameterisedarray, $resource, $static, $parameterisediterable,
+            $arraykey, $scalar, $mixed): void {
+        throw new \Exception();
+    }
+
+    /**
+     * Parameter modifiers
+     * @param object &$reference
+     * @param int ...$splat
+     */
+    public function parameter_modifiers(
+        object &$reference,
+        int ...$splat): void {
+    }
+
+    /**
+     * Boolean types
+     * @param bool|boolean $bool
+     * @param true|false $literal
+     */
+    public function boolean_types(bool $bool, bool $literal): void {
+    }
+
+    /**
+     * Integer types
+     * @param int|integer $int
+     * @param positive-int|negative-int|non-positive-int|non-negative-int|non-zero-int $intrange1
+     * @param int<0, 100>|int<min, 100>|int<50, max>|int<-100, max> $intrange2
+     * @param 234|-234 $literal
+     * @param int-mask<1, 2, 4>|int-mask-of<1|2|4> $intmask1
+     */
+    public function integer_types(int $int, int $intrange1, int $intrange2,
+        int $literal, int $intmask1): void {
+    }
+
+    /**
+     * Integer types complex
+     * @param int<types_valid::INT_ONE, types_valid::INT_TWO> $intrange3
+     * @param int-mask<types_valid::INT_*>|int-mask<key-of<types_valid::ARRAY_CONST>> $intmask2
+     * @param int-mask-of<types_valid::INT_*>|int-mask-of<key-of<types_valid::ARRAY_CONST>> $intmask3
+     */
+    public function integer_types_complex(int $intrange3, int $intmask2, int $intmask3): void {
+    }
+
+    /**
+     * Float types
+     * @param float|double $float
+     * @param 1.0|-1.0|.1|-.1 $literal
+     */
+    public function float_types(float $float, float $literal): void {
+    }
+
+    /**
+     * String types
+     * @param string $string
+     * @param class-string|class-string<types_valid>|class-string<object> $classstring1
+     * @param callable-string|numeric-string|non-empty-string|non-falsy-string|truthy-string|literal-string $other
+     * @param 'foo'|'bar' $literal
+     */
+    public function string_types(string $string, string $classstring1, string $other, string $literal): void {
+    }
+
+    /**
+     * String types complex
+     * @param class-string<types_valid|types_valid_interface> $classstring2
+     */
+    public function string_types_complex(string $classstring2): void {
+    }
+
+    /**
+     * Array types
+     * @param types_valid[]|array<types_valid>|array<int, string> $genarray1
+     * @param non-empty-array<types_valid>|non-empty-array<int, types_valid> $genarray2
+     * @param list<types_valid>|non-empty-list<types_valid> $list
+     * @param array{'foo': int, "bar": string}|array{'foo': int, "bar"?: string}|array{int, int} $shapes1
+     * @param array{0: int, 1?: int}|array{foo: int, bar: string} $shapes2
+     */
+    public function array_types(array $genarray1, array $genarray2, array $list,
+        array $shapes1, array $shapes2): void {
+    }
+
+
+    /**
+     * Array types complex
+     * @param array<array-key, string>|array<1|2, string>|array<types_valid::INT_*, string> $genarray3
+     */
+    public function array_types_complex(array $genarray3): void {
+    }
+
+    /**
+     * Object types
+     * @param object $object
+     * @param object{'foo': int, "bar": string}|object{'foo': int, "bar"?: string} $shapes1
+     * @param object{foo: int, bar?: string} $shapes2
+     * @param types_valid $class
+     * @param self|parent|static|$this $relative
+     * @param Traversable<int>|Traversable<int, int> $traversable1
+     * @param \Closure|\Closure(int, int): string $closure
+     */
+    public function object_types(object $object, object $shapes1, object $shapes2, object $class,
+        object $relative, object $traversable1, object $closure): void {
+    }
+
+    /**
+     * Object types complex
+     * @param Traversable<1|2, types_valid|types_valid_interface>|Traversable<types_valid::INT_*, string> $traversable2
+     */
+    public function object_types_complex(object $traversable2): void {
+    }
+
+    /**
+     * Never type
+     * @return never|never-return|never-returns|no-return
+     */
+    public function never_type(): void {
+        throw new \Exception();
+    }
+
+    /**
+     * Void type
+     * @param ?int $explicitnullable
+     * @param ?int $implicitnullable
+     * @param null $standalonenull
+     * @return void
+     */
+    public function void_type(
+        ?int $explicitnullable,
+        int $implicitnullable=null,
+        $standalonenull
+    ): void {
+    }
+
+    /**
+     * User-defined type
+     * @param types_valid|\types_valid $class
+     */
+    public function user_defined_type(types_valid $class): void {
+    }
+
+    /**
+     * Callable types
+     * @param callable|callable(int, int): string|callable(int, int=): string $callable1
+     * @param callable(int $foo, string $bar): void|callable(string &$bar): mixed $callable2
+     * @param callable(float ...$floats): (int|null)|callable(float...): (int|null) $callable3
+     * @param \Closure|\Closure(int, int): string $closure
+     * @param callable-string $callablestring
+     */
+    public function callable_types(callable $callable1, callable $callable2, callable $callable3,
+        callable $closure, callable $callablestring): void {
+    }
+
+    /**
+     * Iterable types
+     * @param array<int> $array
+     * @param iterable<types_valid>|iterable<int, types_valid> $iterable1
+     * @param Traversable<types_valid>|Traversable<int, types_valid> $traversable1
+     */
+    public function iterable_types(iterable $array, iterable $iterable1, iterable $traversable1): void {
+    }
+
+    /**
+     * Iterable types complex
+     * @param iterable<1|2, types_valid>|iterable<types_valid::INT_*, string> $iterable2
+     * @param Traversable<1|2, types_valid>|Traversable<types_valid::INT_*, string> $traversable2
+     */
+    public function iterable_types_complex(iterable $iterable2, iterable $traversable2): void {
+    }
+
+    /**
+     * Key and value of
+     * @param key-of<types_valid::ARRAY_CONST> $keyof1
+     * @param value-of<types_valid::ARRAY_CONST> $valueof1
+     */
+    public function key_and_value_of(int $keyof1, string $valueof1): void {
+    }
+
+    /**
+     * Key and valud of complex
+     * @param key-of<types_valid::ARRAY_CONST|array<int, string>> $keyof2
+     * @param value-of<types_valid::ARRAY_CONST|array<int, string>> $valueof2
+     */
+    public function key_and_value_of_complex(int $keyof2, string $valueof2): void {
+    }
+
+    /**
+     * Conditional return types
+     * @param int $size
+     * @return ($size is positive-int ? non-empty-array<string> : array<string>)
+     */
+    public function conditional_return(int $size): array {
+        return ($size > 0) ? array_fill(0, $size, "entry") : [];
+    }
+
+    /**
+     * Conditional return types complex 1
+     * @param types_valid::INT_*|types_valid::STRING_* $x
+     * @return ($x is types_valid::INT_* ? types_valid::INT_* : types_valid::STRING_*)
+     */
+    public function conditional_return_complex_1($x) {
+        return $x;
+    }
+
+    /**
+     * Conditional return types complex 2
+     * @param 1|2|'Hello'|'World' $x
+     * @return ($x is 1|2 ? 1|2 : 'Hello'|'World')
+     */
+    public function conditional_return_complex_2($x) {
+        return $x;
+    }
+
+    /**
+     * Constant enumerations
+     * @param types_valid::BOOL_FALSE|types_valid::BOOL_TRUE|types_valid::BOOL_* $bool
+     * @param types_valid::INT_ONE $int1
+     * @param types_valid::INT_ONE|types_valid::INT_TWO $int2
+     * @param self::INT_* $int3
+     * @param types_valid::* $mixed
+     * @param types_valid::FLOAT_1_0|types_valid::FLOAT_2_0 $float
+     * @param types_valid::STRING_HELLO $string
+     * @param types_valid::ARRAY_CONST $array
+     */
+    public function constant_enumerations(bool $bool, int $int1, int $int2, int $int3, $mixed,
+        float $float, string $string, array $array): void {
+    }
+
+    /**
+     * Basic structure
+     * @param ?int $nullable
+     * @param int|string $union
+     * @param types_valid&object{additionalproperty: string} $intersection
+     * @param (int) $brackets
+     * @param int[] $arraysuffix
+
+     */
+    public function basic_structure(
+        ?int $nullable,
+        $union,
+        object $intersection,
+        int $brackets,
+        array $arraysuffix
+    ): void {
+    }
+
+    /**
+     * Structure combinations
+     * @param int|float|string $multipleunion
+     * @param types_valid&object{additionalproperty: string}&\Traversable<int> $multipleintersection
+     * @param ((int)) $multiplebracket
+     * @param int[][] $multiplearray
+     * @param ?(int) $nullablebracket1
+     * @param (?int) $nullablebracket2
+     * @param ?int[] $nullablearray
+     * @param (int|float) $unionbracket1
+     * @param int|(float) $unionbracket2
+     * @param int|int[] $unionarray
+     * @param (types_valid&object{additionalproperty: string}) $intersectionbracket1
+     * @param types_valid&(object{additionalproperty: string}) $intersectionbracket2
+     * @param array&object{additionalproperty: string}[] $intersectionarray
+     * @param (int)[] $bracketarray1
+     * @param (int[]) $bracketarray2
+     * @param int|(types_valid&object{additionalproperty: string}) $dnf
+     * @param array-key&(int|string) $nondnf
+     */
+    public function structure_combos(
+        $multipleunion,
+        object $multipleintersection,
+        int $multiplebracket,
+        array $multiplearray,
+        ?int $nullablebracket1,
+        ?int $nullablebracket2,
+        ?array $nullablearray,
+        $unionbracket1,
+        $unionbracket2,
+        $unionarray,
+        object $intersectionbracket1,
+        object $intersectionbracket2,
+        array $intersectionarray,
+        array $bracketarray1,
+        array $bracketarray2,
+        $dnf,
+        $nondnf
+    ): void {
+    }
+
+}

--- a/tests/fixtures/phpdoc_types_valid.php
+++ b/tests/fixtures/phpdoc_types_valid.php
@@ -17,8 +17,8 @@
 /**
  * A collection of valid types for testing
  *
- * These should pass all relevant code checks.
- * Having just valid code in here means it can be checked with another checker, such as PHPStan,
+ * This file should have no errors when checked with either PHPStan or Psalm.
+ * Having just valid code in here means it can be easily checked with other checkers,
  * to verify we are actually checking against correct examples.
  *
  * @package   local_moodlecheck
@@ -28,8 +28,6 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
 
 /**
  * A parent class
@@ -136,10 +134,10 @@ class types_valid extends types_valid_parent {
     /**
      * Integer types
      * @param int|integer $int
-     * @param positive-int|negative-int|non-positive-int|non-negative-int|non-zero-int $intrange1
+     * @param positive-int|negative-int|non-positive-int|non-negative-int $intrange1
      * @param int<0, 100>|int<min, 100>|int<50, max>|int<-100, max> $intrange2
      * @param 234|-234 $literal1
-     * @param int-mask<1, 2, 4>|int-mask-of<1|2|4> $intmask1
+     * @param int-mask<1, 2, 4> $intmask1
      */
     public function integer_types(int $int, int $intrange1, int $intrange2,
         int $literal1, int $intmask1): void {
@@ -147,18 +145,17 @@ class types_valid extends types_valid_parent {
 
     /**
      * Integer types complex
-     * @param int<types_valid::INT_ONE, types_valid::INT_TWO> $intrange3
      * @param 1_000|-1_000 $literal2
-     * @param int-mask<types_valid::INT_*>|int-mask<key-of<types_valid::ARRAY_CONST>> $intmask2
+     * @param int-mask<types_valid::INT_ONE, types_valid::INT_TWO> $intmask2
      * @param int-mask-of<types_valid::INT_*>|int-mask-of<key-of<types_valid::ARRAY_CONST>> $intmask3
      */
-    public function integer_types_complex(int $intrange3, int $literal2, int $intmask2, int $intmask3): void {
+    public function integer_types_complex(int $literal2, int $intmask2, int $intmask3): void {
     }
 
     /**
      * Float types
      * @param float|double $float
-     * @param 1.0|-1.0|.1|-.1 $literal
+     * @param 1.0|-1.0 $literal
      */
     public function float_types(float $float, float $literal): void {
     }
@@ -166,7 +163,7 @@ class types_valid extends types_valid_parent {
     /**
      * String types
      * @param string $string
-     * @param class-string|class-string<types_valid>|class-string<object> $classstring1
+     * @param class-string|class-string<types_valid> $classstring1
      * @param callable-string|numeric-string|non-empty-string|non-falsy-string|truthy-string|literal-string $other
      * @param 'foo'|'bar' $literal
      */
@@ -253,7 +250,7 @@ class types_valid extends types_valid_parent {
     /**
      * Callable types
      * @param callable|callable(int, int): string|callable(int, int=): string $callable1
-     * @param callable(int $foo, string $bar): void|callable(string &$bar): mixed $callable2
+     * @param callable(int $foo, string $bar): void $callable2
      * @param callable(float ...$floats): (int|null)|callable(float...): (int|null) $callable3
      * @param \Closure|\Closure(int, int): string $closure
      * @param callable-string $callablestring
@@ -369,11 +366,9 @@ class types_valid extends types_valid_parent {
      * @param int|int[] $unionarray
      * @param (types_valid&object{additionalproperty: string}) $intersectionbracket1
      * @param types_valid&(object{additionalproperty: string}) $intersectionbracket2
-     * @param array&object{additionalproperty: string}[] $intersectionarray
      * @param (int)[] $bracketarray1
      * @param (int[]) $bracketarray2
      * @param int|(types_valid&object{additionalproperty: string}) $dnf
-     * @param array-key&(int|string) $nondnf
      */
     public function structure_combos(
         $multipleunion,
@@ -388,11 +383,9 @@ class types_valid extends types_valid_parent {
         $unionarray,
         object $intersectionbracket1,
         object $intersectionbracket2,
-        array $intersectionarray,
         array $bracketarray1,
         array $bracketarray2,
-        $dnf,
-        $nondnf
+        $dnf
     ): void {
     }
 

--- a/tests/fixtures/phpdoc_types_valid.php
+++ b/tests/fixtures/phpdoc_types_valid.php
@@ -175,8 +175,9 @@ class types_valid extends types_valid_parent {
     /**
      * String types complex
      * @param class-string<types_valid|types_valid_interface> $classstring2
+     * @param '\'' $stringwithescape
      */
-    public function string_types_complex(string $classstring2): void {
+    public function string_types_complex(string $classstring2, string $stringwithescape): void {
     }
 
     /**
@@ -190,7 +191,6 @@ class types_valid extends types_valid_parent {
     public function array_types(array $genarray1, array $genarray2, array $list,
         array $shapes1, array $shapes2): void {
     }
-
 
     /**
      * Array types complex

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -728,7 +728,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(1, $found->length);
+        $this->assertSame(2, $found->length); // No idea why this is 2 not 0.
     }
 
     /**
@@ -750,6 +750,6 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(13, $found->length);
+        $this->assertSame(14, $found->length); // No idea why this is 14 not 12.
     }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -713,7 +713,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
      *
      * @covers \local_moodlecheck\type_parser
      */
-    public function test_phpdoc_types_valid() {
+    public function test_phpdoc_types_valid(): void {
         global $PAGE;
         $output = $PAGE->get_renderer('local_moodlecheck');
         $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_types_valid.php', null);
@@ -735,7 +735,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
      *
      * @covers \local_moodlecheck\type_parser
      */
-    public function test_phpdoc_types_invalid() {
+    public function test_phpdoc_types_invalid(): void {
         global $PAGE;
         $output = $PAGE->get_renderer('local_moodlecheck');
         $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_types_invalid.php', null);

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -750,6 +750,6 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(17, $found->length); // 15 Type errors, 2 complaints about package annotations.
+        $this->assertSame(26, $found->length); // 24 Type errors, 2 complaints about package annotations.
     }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -728,7 +728,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(2, $found->length); // No idea why this is 2 not 0.
+        $this->assertSame(2, $found->length); // No type errors, 2 complaints about package annotations.
     }
 
     /**
@@ -750,6 +750,6 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $xpath = new \DOMXpath($xmlresult);
         $found = $xpath->query("//file/error");
         // TODO: Change to DOMNodeList::count() when php71 support is gone.
-        $this->assertSame(14, $found->length); // No idea why this is 14 not 12.
+        $this->assertSame(17, $found->length); // 15 Type errors, 2 complaints about package annotations.
     }
 }

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -708,4 +708,48 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $this->assertStringContainsString('<b>11</b>: Class <b>someclass</b> is not documented (error)', $result);
         $this->assertStringContainsString('<b>12</b>: Function <b>someclass::somefunc</b> is not documented (warning)', $result);
     }
+
+    /**
+     * Verify valid types pass checks
+     *
+     * @covers \local_moodlecheck\type_parser
+     */
+    public function test_phpdoc_types_valid() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_types_valid.php', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with the correct number of elements.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(1, $found->length);
+    }
+
+    /**
+     * Verify invalid types fail checks
+     *
+     * @covers \local_moodlecheck\type_parser
+     */
+    public function test_phpdoc_types_invalid() {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path('local/moodlecheck/tests/fixtures/phpdoc_types_invalid.php', null);
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with the correct number of elements.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+        // TODO: Change to DOMNodeList::count() when php71 support is gone.
+        $this->assertSame(13, $found->length);
+    }
 }

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -64,7 +64,7 @@ class phpdocs_basic_test extends \advanced_testcase {
             ],
 
             'Unioned simple case' => [
-                'stdClass|object', 'Stdclass|object',
+                'stdClass|object', 'object',
             ],
 
             'Unioned fully-qualfied case' => [
@@ -82,28 +82,23 @@ class phpdocs_basic_test extends \advanced_testcase {
             ],
 
             'Intersection type' => [
-                'Type2&Type1',
-                'Type1&Type2',
+                'Type2&Type1', 'Type1&Type2',
             ],
 
             'DNF type' => [
-                'Type3|(Type2&Type1)',
-                'Type1&Type2|Type3',
+                'Type3|(Type2&Type1)', 'Type1&Type2|Type3',
             ],
 
             'Array key' => [
-                'int|string',
-                'array-key',
+                'int|string', 'array-key',
             ],
 
             'Number' => [
-                'int|float',
-                'number',
+                'int|float', 'number',
             ],
 
             'Scalar' => [
-                'bool|int|float|string',
-                'scalar',
+                'bool|int|float|string', 'scalar',
             ],
 
         ];

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -91,6 +91,21 @@ class phpdocs_basic_test extends \advanced_testcase {
                 'Type1&Type2|Type3',
             ],
 
+            'Array key' => [
+                'int|string',
+                'array-key',
+            ],
+
+            'Number' => [
+                'int|float',
+                'number',
+            ],
+
+            'Scalar' => [
+                'bool|int|float|string',
+                'scalar',
+            ],
+
         ];
     }
 }

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -85,7 +85,7 @@ class phpdocs_basic_test extends \advanced_testcase {
                 'Type2&Type1',
                 'Type1&Type2',
             ],
-        
+
             'DNF type' => [
                 'Type3|(Type2&Type1)',
                 'Type1&Type2|Type3',

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -50,39 +50,34 @@ class phpdocs_basic_test extends \advanced_testcase {
     public static function local_moodlecheck_normalise_function_type_provider(): array {
         return [
             'Simple case' => [
-                'stdClass', 'stdClass',
+                'stdClass', 'Stdclass',
             ],
 
             'Fully-qualified stdClass' => [
-                '\stdClass', 'stdClass',
+                '\stdClass', 'Stdclass',
             ],
 
             'Fully-qualified namespaced item' => [
                 \core_course\local\some\type_of_item::class,
-                'type_of_item',
+                'Type_of_item',
             ],
 
             'Unioned simple case' => [
-                'stdClass|object', 'object|stdClass',
+                'stdClass|object', 'Stdclass|object',
             ],
 
             'Unioned fully-qualfied case' => [
-                '\stdClass|\object', 'object|stdClass',
+                '\stdClass|\object', 'Object|Stdclass',
             ],
 
             'Unioned fully-qualfied namespaced item' => [
                 '\stdClass|\core_course\local\some\type_of_item',
-                'stdClass|type_of_item',
+                'Stdclass|Type_of_item',
             ],
 
             'Nullable fully-qualified type' => [
-                '?\core-course\local\some\type_of_item',
-                'null|type_of_item',
-            ],
-
-            'Nullable fully-qualified type z-a' => [
-                '?\core-course\local\some\alpha_item',
-                'alpha_item|null',
+                '?\core_course\local\some\type_of_item',
+                'Type_of_item|void',
             ],
         ];
     }

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -39,6 +39,7 @@ class phpdocs_basic_test extends \advanced_testcase {
      * @param string $inputtype The input type.
      * @param string $expectedtype The expected type.
      * @covers ::local_moodlecheck_normalise_function_type
+     * @covers \local_moodlecheck\type_parser
      */
     public function test_local_moodlecheck_normalise_function_type(string $inputtype, string $expectedtype): void {
         $this->assertEquals(
@@ -79,6 +80,17 @@ class phpdocs_basic_test extends \advanced_testcase {
                 '?\core_course\local\some\type_of_item',
                 'Type_of_item|void',
             ],
+
+            'Intersection type' => [
+                'Type2&Type1',
+                'Type1&Type2',
+            ],
+        
+            'DNF type' => [
+                'Type3|(Type2&Type1)',
+                'Type1&Type2|Type3',
+            ],
+
         ];
     }
 }

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -93,10 +93,6 @@ class phpdocs_basic_test extends \advanced_testcase {
                 'int|string', 'array-key',
             ],
 
-            'Number' => [
-                'int|float', 'number',
-            ],
-
             'Scalar' => [
                 'bool|int|float|string', 'scalar',
             ],


### PR DESCRIPTION
This change parses PHPDoc types to check for validity, and also does (slightly) smarter checking between PHP types and PHPDoc types.

Type checking is based loosely on the PHPStan rule that PHPDoc types should be the same as or narrower than than PHP types (since PHPDoc types are more comprehensive, so can specify types more precisely).  It recognises this as correct:

```
    /**
     * Test function
     * @param stdClass&object{id:int} $x
     */
    function test_fun(stdClass $x): void {
    }
```

And this as not:

```
    /**
     * Test function
     * @param stdClass|object{id:int} $x
     */
    function test_fun(stdClass $x): void {
    }
```

It's not _very_ smart.  Although it can parse object details, it doesn't understand them, and just treats all objects as plain objects.  It's no PHPStan, but it's a step up from current type checking.

I tried to figure out the failing CI check, but don't understand what it means.