### PR TITLE
Address new CI array rules

### DIFF
--- a/cli/moodlecheck.php
+++ b/cli/moodlecheck.php
@@ -30,14 +30,14 @@ require_once($CFG->dirroot. '/local/moodlecheck/locallib.php');
 
 // Now get cli options.
 list($options, $unrecognized) = cli_get_params(
-        array('help' => false, 'path' => '', 'format' => 'xml', 'exclude' => '', 'rules' => 'all', 'componentsfile' => ''),
-        array('h' => 'help', 'p' => 'path', 'f' => 'format', 'e' => 'exclude', 'r' => 'rules', 'c' => 'componentsfile')
+        ['help' => false, 'path' => '', 'format' => 'xml', 'exclude' => '', 'rules' => 'all', 'componentsfile' => ''],
+        ['h' => 'help', 'p' => 'path', 'f' => 'format', 'e' => 'exclude', 'r' => 'rules', 'c' => 'componentsfile']
     );
 
 $rules = preg_split('/\s*[\n,;]\s*/', trim($options['rules']), -1, PREG_SPLIT_NO_EMPTY);
 $paths = preg_split('/\s*[\n,;]\s*/', trim($options['path']), -1, PREG_SPLIT_NO_EMPTY);
 $exclude = preg_split('/\s*[\n,;]\s*/', trim($options['exclude']), -1, PREG_SPLIT_NO_EMPTY);
-if (!in_array($options['format'], array('xml', 'html', 'text'))) {
+if (!in_array($options['format'], ['xml', 'html', 'text'])) {
     unset($options['format']);
 }
 

--- a/file.php
+++ b/file.php
@@ -115,7 +115,7 @@ class local_moodlecheck_file {
         if ($this->errors !== null) {
             return $this->errors;
         }
-        $this->errors = array();
+        $this->errors = [];
         if (!$this->needs_validation()) {
             return $this->errors;
         }
@@ -123,12 +123,12 @@ class local_moodlecheck_file {
         if (!$this->get_tokens() ||
                 count($this->get_tokens()) === 1 ||
                 (isset($this->get_tokens()[0][0]) && $this->get_tokens()[0][0] !== T_OPEN_TAG)) {
-            $this->errors[] = array(
+            $this->errors[] = [
                 'line' => 1,
                 'severity' => 'error',
                 'message' => get_string('error_emptynophpfile', 'local_moodlecheck'),
-                'source' => '&#x00d8;'
-            );
+                'source' => '&#x00d8;',
+            ];
             return $this->errors;
         }
         foreach (local_moodlecheck_registry::get_enabled_rules() as $code => $rule) {
@@ -167,7 +167,7 @@ class local_moodlecheck_file {
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if (is_string($this->tokens[$tid])) {
                     // Simple 1-character token.
-                    $this->tokens[$tid] = array(-1, $this->tokens[$tid]);
+                    $this->tokens[$tid] = [-1, $this->tokens[$tid]];
                 }
                 // And now, for the purpose of this project we don't need strings with variables inside to be parsed
                 // so when we find string in double quotes that is split into several tokens and combine all content in one token.
@@ -177,12 +177,12 @@ class local_moodlecheck_file {
                         $this->tokens[$tid][0] = T_STRING;
                     } else {
                         $this->tokens[$inquotes][1] .= $this->tokens[$tid][1];
-                        $this->tokens[$tid] = array(T_WHITESPACE, '');
+                        $this->tokens[$tid] = [T_WHITESPACE, ''];
                         $inquotes = -1;
                     }
                 } else if ($inquotes > -1) {
                     $this->tokens[$inquotes][1] .= $this->tokens[$tid][1];
-                    $this->tokens[$tid] = array(T_WHITESPACE, '');
+                    $this->tokens[$tid] = [T_WHITESPACE, ''];
                 }
             }
         }
@@ -205,12 +205,12 @@ class local_moodlecheck_file {
      * @return array with 3 elements (classes, interfaces & traits), each being an array.
      */
     public function get_artifacts() {
-        $types = array(T_CLASS, T_INTERFACE, T_TRAIT); // We are interested on these.
+        $types = [T_CLASS, T_INTERFACE, T_TRAIT]; // We are interested on these.
         $artifacts = array_combine($types, $types);
         if ($this->classes === null) {
-            $this->classes = array();
-            $this->interfaces = array();
-            $this->traits = array();
+            $this->classes = [];
+            $this->interfaces = [];
+            $this->traits = [];
             $tokens = &$this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if (isset($artifacts[$this->tokens[$tid][0]])) {
@@ -296,7 +296,7 @@ class local_moodlecheck_file {
                 }
             }
         }
-        return array(T_CLASS => $this->classes, T_INTERFACE => $this->interfaces, T_TRAIT => $this->traits);
+        return [T_CLASS => $this->classes, T_INTERFACE => $this->interfaces, T_TRAIT => $this->traits];
     }
 
     /**
@@ -337,14 +337,14 @@ class local_moodlecheck_file {
      * $function->accessmodifiers : tokens like static, public, protected, abstract, etc.
      * $function->tagpair : array of two elements: id of token { for the function and id of token } (false if not found)
      * $function->argumentstoken : array of tokens found inside function arguments
-     * $function->arguments : array of function arguments where each element is array(typename, variablename)
+     * $function->arguments : array of function arguments where each element is [typename, variablename]
      * $function->boundaries : array with ids of first and last token for this function
      *
      * @return array
      */
     public function &get_functions() {
         if ($this->functions === null) {
-            $this->functions = array();
+            $this->functions = [];
             $tokens = &$this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if ($this->tokens[$tid][0] == T_USE) {
@@ -356,7 +356,7 @@ class local_moodlecheck_file {
                 if ($this->tokens[$tid][0] == T_FUNCTION) {
                     $function = new stdClass();
                     $function->tid = $tid;
-                    $function->fullname = $function->name = $this->next_nonspace_token($tid, false, array('&'));
+                    $function->fullname = $function->name = $this->next_nonspace_token($tid, false, ['&']);
 
                     // Skip anonymous functions.
                     if ($function->name == '(') {
@@ -375,14 +375,14 @@ class local_moodlecheck_file {
                         $function->tagpair = false;
                     }
 
-                    $argumentspair = $this->find_tag_pair($tid, '(', ')', array('{', ';'));
+                    $argumentspair = $this->find_tag_pair($tid, '(', ')', ['{', ';']);
                     if ($argumentspair !== false && $argumentspair[1] - $argumentspair[0] > 1) {
                         $function->argumentstokens = $this->break_tokens_by(
                             array_slice($tokens, $argumentspair[0] + 1, $argumentspair[1] - $argumentspair[0] - 1) );
                     } else {
-                        $function->argumentstokens = array();
+                        $function->argumentstokens = [];
                     }
-                    $function->arguments = array();
+                    $function->arguments = [];
                     foreach ($function->argumentstokens as $argtokens) {
                         // If the token is completely empty then it's not an argument. This happens, for example, with
                         // trailing commas in parameters, allowed since PHP 8.0 and break_tokens_by() returns it that way.
@@ -461,7 +461,7 @@ class local_moodlecheck_file {
 
                         $type = implode('|', $possibletypes);
 
-                        $function->arguments[] = array($type, $variable);
+                        $function->arguments[] = [$type, $variable];
                     }
                     $function->boundaries = $this->find_object_boundaries($function);
                     $this->functions[] = $function;
@@ -487,7 +487,7 @@ class local_moodlecheck_file {
      */
     public function &get_variables() {
         if ($this->variables === null) {
-            $this->variables = array();
+            $this->variables = [];
             $this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if ($this->tokens[$tid][0] == T_VARIABLE && ($class = $this->is_inside_class($tid)) &&
@@ -525,7 +525,7 @@ class local_moodlecheck_file {
      */
     public function &get_constants() {
         if ($this->constants === null) {
-            $this->constants = array();
+            $this->constants = [];
             $this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if ($this->tokens[$tid][0] == T_USE) {
@@ -566,7 +566,7 @@ class local_moodlecheck_file {
      */
     public function &get_defines() {
         if ($this->defines === null) {
-            $this->defines = array();
+            $this->defines = [];
             $this->get_tokens();
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
                 if ($this->tokens[$tid][0] == T_STRING && $this->tokens[$tid][1] == 'define' &&
@@ -599,7 +599,7 @@ class local_moodlecheck_file {
      * @return array
      */
     public function find_object_boundaries($obj) {
-        $boundaries = array($obj->tid, $obj->tid);
+        $boundaries = [$obj->tid, $obj->tid];
         $tokens = &$this->get_tokens();
         if (!empty($obj->tagpair)) {
             $boundaries[1] = $obj->tagpair[1];
@@ -618,15 +618,15 @@ class local_moodlecheck_file {
             // Walk back until we meet one of the characters that means that we are outside of the object.
             for ($i = $boundaries[0] - 1; $i >= 0; $i--) {
                 $token = $tokens[$i];
-                if (in_array($token[0], array(T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG))) {
+                if (in_array($token[0], [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG])) {
                     break;
-                } else if (in_array($token[1], array('{', '}', '(', ';', ',', '['))) {
+                } else if (in_array($token[1], ['{', '}', '(', ';', ',', '['])) {
                     break;
                 }
             }
             // Walk forward to the next meaningful token skipping all spaces and comments.
             for ($i = $i + 1; $i < $boundaries[0]; $i++) {
-                if (!in_array($tokens[$i][0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT))) {
+                if (!in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])) {
                     break;
                 }
             }
@@ -717,7 +717,7 @@ class local_moodlecheck_file {
      * @param array $alsoignore
      * @return int|false
      */
-    public function next_nonspace_token($tid, $returnid = false, $alsoignore = array()) {
+    public function next_nonspace_token($tid, $returnid = false, $alsoignore = []) {
         $this->get_tokens();
         for ($i = $tid + 1; $i < $this->tokenscount; $i++) {
             if (!$this->is_whitespace_token($i) && !in_array($this->tokens[$i][1], $alsoignore)) {
@@ -741,7 +741,7 @@ class local_moodlecheck_file {
      * @param array $alsoignore
      * @return int|false
      */
-    public function previous_nonspace_token($tid, $returnid = false, $alsoignore = array()) {
+    public function previous_nonspace_token($tid, $returnid = false, $alsoignore = []) {
         $this->get_tokens();
         for ($i = $tid - 1; $i > 0; $i--) {
             if (!$this->is_whitespace_token($i) && !in_array($this->tokens[$i][1], $alsoignore)) {
@@ -781,7 +781,7 @@ class local_moodlecheck_file {
      */
     public function find_access_modifiers($tid) {
         $tokens = &$this->get_tokens();
-        $modifiers = array();
+        $modifiers = [];
         for ($i = $tid - 1; $i >= 0; $i--) {
             if ($this->is_whitespace_token($i)) {
                 // Skip.
@@ -818,7 +818,7 @@ class local_moodlecheck_file {
             } else if (in_array($tokens[$i][0], $modifiers)) {
                 // Just skip.
                 continue;
-            } else if (in_array($tokens[$i][1], array('{', '}', ';'))) {
+            } else if (in_array($tokens[$i][1], ['{', '}', ';'])) {
                 // This means that no phpdocs exists.
                 return false;
             } else if ($tokens[$i][0] == T_COMMENT) {
@@ -874,7 +874,7 @@ class local_moodlecheck_file {
      * @param array $breakifmeet array of symbols that are not allowed not preceed the $opensymbol
      * @return array|false array of ids of two corresponding tokens or false if not found
      */
-    public function find_tag_pair($startid, $opensymbol, $closesymbol, $breakifmeet = array()) {
+    public function find_tag_pair($startid, $opensymbol, $closesymbol, $breakifmeet = []) {
         $openid = false;
         $counter = 0;
         // Also break if we find closesymbol before opensymbol.
@@ -885,7 +885,7 @@ class local_moodlecheck_file {
             } else if ($openid !== false && $this->tokens[$i][1] == $closesymbol) {
                 $counter--;
                 if ($counter == 0) {
-                    return array($openid, $i);
+                    return [$openid, $i];
                 }
             } else if ($this->tokens[$i][1] == $opensymbol) {
                 if ($openid === false) {
@@ -907,7 +907,7 @@ class local_moodlecheck_file {
      * @param array $breakifmeet array of symbols that are not allowed not preceed the $opensymbol
      * @return array|false array of ids of two corresponding tokens or false if not found
      */
-    public function find_tag_pair_inlist(&$tokens, $startid, $opensymbol, $closesymbol, $breakifmeet = array()) {
+    public function find_tag_pair_inlist(&$tokens, $startid, $opensymbol, $closesymbol, $breakifmeet = []) {
         $openid = false;
         $counter = 0;
         // Also break if we find closesymbol before opensymbol.
@@ -919,7 +919,7 @@ class local_moodlecheck_file {
             } else if ($openid !== false && $tokens[$i][1] == $closesymbol) {
                 $counter--;
                 if ($counter == 0) {
-                    return array($openid, $i);
+                    return [$openid, $i];
                 }
             } else if ($tokens[$i][1] == $opensymbol) {
                 if ($openid === false) {
@@ -941,7 +941,7 @@ class local_moodlecheck_file {
         if ($this->filephpdocs === null) {
             $found = false;
             for ($tid = 0; $tid < $this->tokenscount; $tid++) {
-                if (in_array($tokens[$tid][0], array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT))) {
+                if (in_array($tokens[$tid][0], [T_OPEN_TAG, T_WHITESPACE, T_COMMENT])) {
                     // All allowed before the file-level phpdocs.
                     $found = false;
                 } else if ($tokens[$tid][0] == T_DOC_COMMENT) {
@@ -961,13 +961,13 @@ class local_moodlecheck_file {
                         // At least one empty line follows, it's all right.
                         $found = $tid;
                     } else if (in_array($nexttoken[0],
-                            array(T_DOC_COMMENT, T_COMMENT, T_REQUIRE_ONCE, T_REQUIRE, T_IF, T_INCLUDE_ONCE, T_INCLUDE))) {
+                            [T_DOC_COMMENT, T_COMMENT, T_REQUIRE_ONCE, T_REQUIRE, T_IF, T_INCLUDE_ONCE, T_INCLUDE])) {
                         // Something non-documentable following, ok.
                         $found = $tid;
                     } else if ($nexttoken[0] == T_STRING && $nexttoken[1] == 'defined') {
                         // Something non-documentable following.
                         $found = $tid;
-                    } else if (in_array($nexttoken[0], array(T_CLASS, T_ABSTRACT, T_INTERFACE, T_FUNCTION))) {
+                    } else if (in_array($nexttoken[0], [T_CLASS, T_ABSTRACT, T_INTERFACE, T_FUNCTION])) {
                         // This is the doc comment to the following class/function.
                         $found = false;
                     }
@@ -992,7 +992,7 @@ class local_moodlecheck_file {
      */
     public function &get_all_phpdocs() {
         if ($this->allphpdocs === null) {
-            $this->allphpdocs = array();
+            $this->allphpdocs = [];
             $this->get_tokens();
             for ($id = 0; $id < $this->tokenscount; $id++) {
                 if (($this->tokens[$id][0] == T_DOC_COMMENT || $this->tokens[$id][0] === T_COMMENT)) {
@@ -1029,14 +1029,14 @@ class local_moodlecheck_file {
      * @return array of arrays of tokens
      */
     public function break_tokens_by($tokens, $separator = ',') {
-        $rv = array();
+        $rv = [];
         if (!count($tokens)) {
             return $rv;
         }
-        $rv[] = array();
+        $rv[] = [];
         for ($i = 0; $i < count($tokens); $i++) {
             if ($tokens[$i][1] == $separator) {
-                $rv[] = array();
+                $rv[] = [];
             } else {
                 $nextpair = false;
                 if ($tokens[$i][1] == '(') {
@@ -1097,7 +1097,7 @@ class local_moodlecheck_phpdocs {
     /** @var array static property storing the list of valid,
      * well known, phpdocs tags, always accepted.
      * @link http://manual.phpdoc.org/HTMLSmartyConverter/HandS/ */
-    public static $validtags = array(
+    public static $validtags = [
         // Behat tags.
         'Given',
         'Then',
@@ -1150,12 +1150,12 @@ class local_moodlecheck_phpdocs {
         'tutorial',
         'uses',
         'var',
-        'version'
-    );
+        'version',
+    ];
     /** @var array static property storing the list of recommended
      * phpdoc tags to use within Moodle phpdocs.
      * @link http://docs.moodle.org/dev/Coding_style */
-    public static $recommendedtags = array(
+    public static $recommendedtags = [
         // Behat tags.
         'Given',
         'Then',
@@ -1194,34 +1194,34 @@ class local_moodlecheck_phpdocs {
         'throws',
         'todo',
         'uses',
-        'var'
-    );
+        'var',
+    ];
     /** @var array static property storing the list of phpdoc tags
      * allowed to be used under certain directories. keys are tags, values are
      * arrays of allowed paths (regexp patterns).
      */
-    public static $pathrestrictedtags = array(
-        'Given' => array('#.*/tests/behat/.*#'),
-        'Then' => array('#.*/tests/behat/.*#'),
-        'When' => array('#.*/tests/behat/.*#'),
-        'covers' => array('#.*/tests/.*_test.php#'),
-        'coversDefaultClass' => array('#.*/tests/.*_test.php#'),
-        'coversNothing' => array('#.*/tests/.*_test.php#'),
-        'dataProvider' => array('#.*/tests/.*_test.php#'),
-        'depends' => array('#.*/tests/.*_test.php#'),
-        'group' => array('#.*/tests/.*_test.php#'),
-        'requires' => array('#.*/tests/.*_test.php#'),
-        'runTestsInSeparateProcesses' => array('#.*/tests/.*_test.php#'),
-        'runInSeparateProcess' => array('#.*/tests/.*_test.php#'),
-        'testWith' => array('#.*/tests/.*_test.php#'),
-        // Commented out: 'uses' => array('#.*/tests/.*_test.php#'), can also be out from tests (Coding style dixit).
-    );
+    public static $pathrestrictedtags = [
+        'Given' => ['#.*/tests/behat/.*#'],
+        'Then' => ['#.*/tests/behat/.*#'],
+        'When' => ['#.*/tests/behat/.*#'],
+        'covers' => ['#.*/tests/.*_test.php#'],
+        'coversDefaultClass' => ['#.*/tests/.*_test.php#'],
+        'coversNothing' => ['#.*/tests/.*_test.php#'],
+        'dataProvider' => ['#.*/tests/.*_test.php#'],
+        'depends' => ['#.*/tests/.*_test.php#'],
+        'group' => ['#.*/tests/.*_test.php#'],
+        'requires' => ['#.*/tests/.*_test.php#'],
+        'runTestsInSeparateProcesses' => ['#.*/tests/.*_test.php#'],
+        'runInSeparateProcess' => ['#.*/tests/.*_test.php#'],
+        'testWith' => ['#.*/tests/.*_test.php#'],
+        // Commented out: 'uses' => ['#.*/tests/.*_test.php#'], can also be out from tests (Coding style dixit).
+    ];
     /** @var array static property storing the list of phpdoc tags
      * allowed to be used inline within Moodle phpdocs. */
-    public static $inlinetags = array(
+    public static $inlinetags = [
         'link',
-        'see'
-    );
+        'see',
+    ];
     /** @var array stores the original token for this phpdocs */
     protected $originaltoken = null;
     /** @var int stores id the original token for this phpdocs */
@@ -1250,12 +1250,12 @@ class local_moodlecheck_phpdocs {
         if (preg_match('|^///|', $token[1])) {
             $this->trimmedtext = substr($token[1], 3);
         } else {
-            $this->trimmedtext = preg_replace(array('|^\s*/\*+|', '|\*+/\s*$|'), '', $token[1]);
+            $this->trimmedtext = preg_replace(['|^\s*/\*+|', '|\*+/\s*$|'], '', $token[1]);
             $this->trimmedtext = preg_replace('|\n[ \t]*\*|', "\n", $this->trimmedtext);
         }
         $lines = preg_split('/\n/', $this->trimmedtext);
 
-        $this->tokens = array();
+        $this->tokens = [];
         $this->description = '';
         $istokenline = false;
         for ($i = 0; $i < count($lines); $i++) {
@@ -1298,7 +1298,7 @@ class local_moodlecheck_phpdocs {
         if ($tag === null) {
             return $this->tokens;
         } else {
-            $rv = array();
+            $rv = [];
             foreach ($this->tokens as $token) {
                 if (preg_match('/^\s*\@'.$tag.'\s([^\0]*)$/', $token.' ', $matches) && (!$nonempty || strlen(trim($matches[1])))) {
                     $rv[] = trim($matches[1]);
@@ -1382,14 +1382,14 @@ class local_moodlecheck_phpdocs {
     /**
      * Returns list of parsed param tokens found in phpdocs
      *
-     * Each element is array(typename, variablename, variabledescription)
+     * Each element is [typename, variablename, variabledescription]
      *
      * @param string $tag tag name to look for. Usually param but may be var for variables
      * @param int $splitlimit maximum number of chunks to return
      * @return array
      */
     public function get_params($tag = 'param', $splitlimit = 3) {
-        $params = array();
+        $params = [];
 
         foreach ($this->get_tags($tag) as $token) {
             $params[] = preg_split('/\s+/', trim($token), $splitlimit); // AKA 'type $name multi-word description'.
@@ -1450,7 +1450,7 @@ class local_moodlecheck_phpdocs {
      * @return array inline tags found in the phpdoc, with contents if specified.
      */
     public function get_inline_tags($withcurly = true, $withcontent = false) {
-        $inlinetags = array();
+        $inlinetags = [];
         // Trim the non-inline phpdocs tags.
         $text = preg_replace('|^\s*@?|m', '', $this->trimmedtext);
         if ($withcurly) {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ $ignore = optional_param('ignorepath', '', PARAM_NOTAGS);
 $checkall = optional_param('checkall', 'all', PARAM_NOTAGS);
 $rules = optional_param_array('rule', [], PARAM_NOTAGS);
 
-$pageparams = array();
+$pageparams = [];
 if ($pathlist) {
     $pageparams['path'] = $pathlist;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -98,14 +98,14 @@ class local_moodlecheck_rule {
     public function validatefile(local_moodlecheck_file $file) {
         $callback = $this->callback;
         $reterrors = $callback($file);
-        $ruleerrors = array();
+        $ruleerrors = [];
         foreach ($reterrors as $args) {
-            $ruleerrors[] = array(
+            $ruleerrors[] = [
                 'line' => $args['line'],
                 'severity' => $args["severity"] ?? $this->severity,
                 'message' => $this->get_error_message($args),
-                'source' => $this->code
-            );
+                'source' => $this->code,
+            ];
         }
         return $ruleerrors;
     }
@@ -119,8 +119,8 @@ class local_moodlecheck_rule {
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class local_moodlecheck_registry {
-    protected static $rules = array();
-    protected static $enabledrules = array();
+    protected static $rules = [];
+    protected static $enabledrules = [];
 
     public static function add_rule($code) {
         $rule = new local_moodlecheck_rule($code);
@@ -200,7 +200,7 @@ class local_moodlecheck_path {
         if (is_file($this->get_fullpath())) {
             $this->file = new local_moodlecheck_file($this->get_fullpath());
         } else if (is_dir($this->get_fullpath())) {
-            $this->subpaths = array();
+            $this->subpaths = [];
             if ($dh = opendir($this->get_fullpath())) {
                 while (($file = readdir($dh)) !== false) {
                     if ($file != '.' && $file != '..' && $file != '.git'  && $file != '.hg' && !$this->is_ignored($file)) {
@@ -255,12 +255,12 @@ class local_moodlecheck_path {
     }
 
     public static function get_components($componentsfile = null) {
-        static $components = array();
+        static $components = [];
         if (!empty($components)) {
             return $components;
         }
         if (empty($componentsfile)) {
-            return array();
+            return [];
         }
         if (file_exists($componentsfile) && is_readable($componentsfile)) {
             $fh = fopen($componentsfile, 'r');
@@ -295,24 +295,24 @@ class local_moodlecheck_form extends moodleform {
         $mform = $this->_form;
 
         $mform->addElement('textarea', 'path', get_string('path', 'local_moodlecheck'),
-            array('rows' => 8, 'cols' => 120));
+            ['rows' => 8, 'cols' => 120]);
         $mform->addHelpButton('path', 'path', 'local_moodlecheck');
 
         $mform->addElement('header', 'selectivecheck', get_string('options'));
         $mform->setExpanded('selectivecheck', false);
 
         $mform->addElement('textarea', 'ignorepath', get_string('ignorepath', 'local_moodlecheck'),
-            array('rows' => 3, 'cols' => 120));
+            ['rows' => 3, 'cols' => 120]);
 
         $mform->addElement('radio', 'checkall', '', get_string('checkallrules', 'local_moodlecheck'), 'all');
         $mform->addElement('radio', 'checkall', '', get_string('checkselectedrules', 'local_moodlecheck'), 'selected');
         $mform->setDefault('checkall', 'all');
 
-        $group = array();
+        $group = [];
         foreach (local_moodlecheck_registry::get_registered_rules() as $code => $rule) {
             $group[] =& $mform->createElement('checkbox', "rule[$code]", ' ', $rule->get_name());
         }
-        $mform->addGroup($group, 'checkboxgroup', '', array('<br>'), false);
+        $mform->addGroup($group, 'checkboxgroup', '', ['<br>'], false);
         foreach (local_moodlecheck_registry::get_registered_rules() as $code => $rule) {
             $group[] =& $mform->createElement('checkbox', "rule[$code]", ' ', $rule->get_name());
             $mform->setDefault("rule[$code]", 0);

--- a/renderer.php
+++ b/renderer.php
@@ -38,9 +38,9 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
         $path->validate();
         if ($path->is_dir()) {
             if ($format == 'html') {
-                $output .= html_writer::start_tag('li', array('class' => 'directory'));
-                $output .= html_writer::tag('span', $path->get_path(), array('class' => 'dirname'));
-                $output .= html_writer::start_tag('ul', array('class' => 'directory'));
+                $output .= html_writer::start_tag('li', ['class' => 'directory']);
+                $output .= html_writer::tag('span', $path->get_path(), ['class' => 'dirname']);
+                $output .= html_writer::start_tag('ul', ['class' => 'directory']);
             } else if ($format == 'xml' && $path->is_rootpath()) {
                 // Insert XML preamble and root element.
                 $output .= '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
@@ -75,11 +75,11 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
         $errors = $file->validate();
         $this->errorcount += count($errors);
         if ($format == 'html') {
-            $output .= html_writer::start_tag('li', array('class' => 'file'));
-            $output .= html_writer::tag('span', $filename, array('class' => 'filename'));
-            $output .= html_writer::start_tag('ul', array('class' => 'file'));
+            $output .= html_writer::start_tag('li', ['class' => 'file']);
+            $output .= html_writer::tag('span', $filename, ['class' => 'filename']);
+            $output .= html_writer::start_tag('ul', ['class' => 'file']);
         } else if ($format == 'xml') {
-            $output .= html_writer::start_tag('file', array('name' => $filename)). "\n";
+            $output .= html_writer::start_tag('file', ['name' => $filename]). "\n";
         } else if ($format == 'text') {
             $output .= $filename. "\n";
         }
@@ -94,7 +94,7 @@ class local_moodlecheck_renderer extends plugin_renderer_base {
                 $error['message'] = get_string('linenum', 'local_moodlecheck', $error['line']) . $error['message'];
             }
             if ($format == 'html') {
-                $output .= html_writer::tag('li', $error['message'], array('class' => 'errorline'));
+                $output .= html_writer::tag('li', $error['message'], ['class' => 'errorline']);
             } else {
                 $error['message'] = strip_tags($error['message']);
                 if ($format == 'text') {

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -58,9 +58,9 @@ local_moodlecheck_registry::add_rule('phpdoccontentsinlinetag')->set_callback('l
 function local_moodlecheck_noemptysecondline(local_moodlecheck_file $file) {
     $tokens = &$file->get_tokens();
     if ($tokens[0][0] == T_OPEN_TAG && !$file->is_whitespace_token(1) && $file->is_multiline_token(0) == 1) {
-        return array();
+        return [];
     }
-    return array(array('line' => 2));
+    return [['line' => 2]];
 }
 
 /**
@@ -73,19 +73,19 @@ function local_moodlecheck_filephpdocpresent(local_moodlecheck_file $file) {
     // This rule doesn't apply if the file is 1-artifact file (see #66).
     $artifacts = $file->get_artifacts();
     if (count($artifacts[T_CLASS]) + count($artifacts[T_INTERFACE]) + count($artifacts[T_TRAIT]) === 1) {
-        return array();
+        return [];
     }
     if ($file->find_file_phpdocs() === false) {
         $tokens = &$file->get_tokens();
         for ($i = 0; $i < 90; $i++) {
-            if (isset($tokens[$i]) && !in_array($tokens[$i][0], array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT))) {
-                return array(array('line' => $file->get_line_number($i)));
+            if (isset($tokens[$i]) && !in_array($tokens[$i][0], [T_OPEN_TAG, T_WHITESPACE, T_COMMENT])) {
+                return [['line' => $file->get_line_number($i)]];
             }
         }
         // For some reason we cound not find the line number.
-        return array(array('line' => ''));
+        return [['line' => '']];
     }
-    return array();
+    return [];
 }
 
 /**
@@ -95,10 +95,10 @@ function local_moodlecheck_filephpdocpresent(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_classesdocumented(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_classes() as $class) {
         if ($class->phpdocs === false) {
-            $errors[] = array('class' => $class->name, 'line' => $file->get_line_number($class->boundaries[0]));
+            $errors[] = ['class' => $class->name, 'line' => $file->get_line_number($class->boundaries[0])];
         }
     }
     return $errors;
@@ -115,7 +115,7 @@ function local_moodlecheck_classesdocumented(local_moodlecheck_file $file) {
  */
 function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
     $isphpunitfile = preg_match('#/tests/.+_test\.php$#', $file->get_filepath());
-    $errors = array();
+    $errors = [];
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs === false) {
             // Exception is made for plain phpunit test methods MDLSITE-3282, MDLSITE-3856.
@@ -128,7 +128,7 @@ function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
             if (!($isphpunitfile && $istestmethod)) {
                 $error = [
                     'function' => $function->fullname,
-                    'line' => $file->get_line_number($function->boundaries[0])
+                    'line' => $file->get_line_number($function->boundaries[0]),
                 ];
 
                 if ($isinsubclass) {
@@ -149,10 +149,10 @@ function local_moodlecheck_functionsdocumented(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_variablesdocumented(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_variables() as $variable) {
         if ($variable->phpdocs === false) {
-            $errors[] = array('variable' => $variable->fullname, 'line' => $file->get_line_number($variable->tid));
+            $errors[] = ['variable' => $variable->fullname, 'line' => $file->get_line_number($variable->tid)];
         }
     }
     return $errors;
@@ -165,10 +165,10 @@ function local_moodlecheck_variablesdocumented(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_constsdocumented(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_constants() as $object) {
         if ($object->phpdocs === false) {
-            $errors[] = array('object' => $object->fullname, 'line' => $file->get_line_number($object->tid));
+            $errors[] = ['object' => $object->fullname, 'line' => $file->get_line_number($object->tid)];
         }
     }
     return $errors;
@@ -181,10 +181,10 @@ function local_moodlecheck_constsdocumented(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_definesdocumented(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_defines() as $object) {
         if ($object->phpdocs === false) {
-            $errors[] = array('object' => $object->fullname, 'line' => $file->get_line_number($object->tid));
+            $errors[] = ['object' => $object->fullname, 'line' => $file->get_line_number($object->tid)];
         }
     }
     return $errors;
@@ -197,10 +197,10 @@ function local_moodlecheck_definesdocumented(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_noinlinephpdocs(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         if ($phpdocs->is_inline()) {
-            $errors[] = array('line' => $phpdocs->get_line_number($file));
+            $errors[] = ['line' => $phpdocs->get_line_number($file)];
         }
     }
     return $errors;
@@ -213,14 +213,14 @@ function local_moodlecheck_noinlinephpdocs(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsinvalidtag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         foreach ($phpdocs->get_tags() as $tag) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
             if (!in_array($tag, local_moodlecheck_phpdocs::$validtags)) {
-                $errors[] = array(
+                $errors[] = [
                     'line' => $phpdocs->get_line_number($file, '@' . $tag),
-                    'tag' => '@' . $tag);
+                    'tag' => '@' . $tag, ];
             }
         }
     }
@@ -234,15 +234,15 @@ function local_moodlecheck_phpdocsinvalidtag(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsnotrecommendedtag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         foreach ($phpdocs->get_tags() as $tag) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
             if (in_array($tag, local_moodlecheck_phpdocs::$validtags) &&
                     !in_array($tag, local_moodlecheck_phpdocs::$recommendedtags)) {
-                $errors[] = array(
+                $errors[] = [
                     'line' => $phpdocs->get_line_number($file, '@' . $tag),
-                    'tag' => '@' . $tag);
+                    'tag' => '@' . $tag, ];
             }
         }
     }
@@ -256,7 +256,7 @@ function local_moodlecheck_phpdocsnotrecommendedtag(local_moodlecheck_file $file
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsinvalidpathtag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         foreach ($phpdocs->get_tags() as $tag) {
             $tag = preg_replace('|^@([^\s]*).*|s', '$1', $tag);
@@ -265,9 +265,9 @@ function local_moodlecheck_phpdocsinvalidpathtag(local_moodlecheck_file $file) {
                     isset(local_moodlecheck_phpdocs::$pathrestrictedtags[$tag])) {
                 // Verify file path matches some of the valid paths for the tag.
                 if (!preg_filter(local_moodlecheck_phpdocs::$pathrestrictedtags[$tag], '$0', $file->get_filepath())) {
-                    $errors[] = array(
+                    $errors[] = [
                         'line' => $phpdocs->get_line_number($file, '@' . $tag),
-                        'tag' => '@' . $tag);
+                        'tag' => '@' . $tag, ];
                 }
             }
         }
@@ -282,14 +282,14 @@ function local_moodlecheck_phpdocsinvalidpathtag(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsinvalidinlinetag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         if ($inlinetags = $phpdocs->get_inline_tags(false)) {
             foreach ($inlinetags as $inlinetag) {
                 if (!in_array($inlinetag, local_moodlecheck_phpdocs::$inlinetags)) {
-                    $errors[] = array(
+                    $errors[] = [
                         'line' => $phpdocs->get_line_number($file, '@' . $inlinetag),
-                        'tag' => '@' . $inlinetag);
+                        'tag' => '@' . $inlinetag, ];
                 }
             }
         }
@@ -303,7 +303,7 @@ function local_moodlecheck_phpdocsinvalidinlinetag(local_moodlecheck_file $file)
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsuncurlyinlinetag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         if ($inlinetags = $phpdocs->get_inline_tags(false)) {
             $curlyinlinetags = $phpdocs->get_inline_tags(true);
@@ -318,9 +318,9 @@ function local_moodlecheck_phpdocsuncurlyinlinetag(local_moodlecheck_file $file)
             }
             foreach ($inlinetags as $inlinetag) {
                 if (in_array($inlinetag, local_moodlecheck_phpdocs::$inlinetags)) {
-                    $errors[] = array(
+                    $errors[] = [
                         'line' => $phpdocs->get_line_number($file, ' @' . $inlinetag),
-                        'tag' => '@' . $inlinetag);
+                        'tag' => '@' . $inlinetag, ];
                 }
             }
         }
@@ -337,7 +337,7 @@ function local_moodlecheck_phpdocsuncurlyinlinetag(local_moodlecheck_file $file)
  * @return array of found errors
  */
 function local_moodlecheck_phpdoccontentsinlinetag(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_all_phpdocs() as $phpdocs) {
         if ($curlyinlinetags = $phpdocs->get_inline_tags(true, true)) {
             foreach ($curlyinlinetags as $curlyinlinetag) {
@@ -348,16 +348,16 @@ function local_moodlecheck_phpdoccontentsinlinetag(local_moodlecheck_file $file)
                         case 'link':
                             // Must be a correct URL with optional description.
                             if (!filter_var($uriorfqsen, FILTER_VALIDATE_URL)) {
-                                $errors[] = array(
+                                $errors[] = [
                                     'line' => $phpdocs->get_line_number($file, ' {@' . $curlyinlinetag),
-                                    'tag' => '{@' . $curlyinlinetag . '}');
+                                    'tag' => '{@' . $curlyinlinetag . '}', ];
                             }
                             break;
                         case 'see': // Must be 1-word (with some chars allowed - FQSEN only.
                             if (str_word_count($uriorfqsen, 0, '\()-_:>$012345789') !== 1) {
-                                $errors[] = array(
+                                $errors[] = [
                                     'line' => $phpdocs->get_line_number($file, ' {@' . $curlyinlinetag),
-                                    'tag' => '{@' . $curlyinlinetag . '}');
+                                    'tag' => '{@' . $curlyinlinetag . '}', ];
                             }
                             break;
                     }
@@ -375,20 +375,20 @@ function local_moodlecheck_phpdoccontentsinlinetag(local_moodlecheck_file $file)
  * @return array of found errors
  */
 function local_moodlecheck_phpdocsfistline(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
 
     if (($phpdocs = $file->find_file_phpdocs()) && !$file->find_file_phpdocs()->get_shortdescription()) {
-        $errors[] = array(
+        $errors[] = [
             'line' => $phpdocs->get_line_number($file),
-            'object' => 'file'
-        );
+            'object' => 'file',
+        ];
     }
     foreach ($file->get_classes() as $class) {
         if ($class->phpdocs && !$class->phpdocs->get_shortdescription()) {
-            $errors[] = array(
+            $errors[] = [
                 'line' => $class->phpdocs->get_line_number($file),
-                'object' => 'class '.$class->name
-            );
+                'object' => 'class '.$class->name,
+            ];
         }
     }
     return $errors;
@@ -401,13 +401,13 @@ function local_moodlecheck_phpdocsfistline(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_functiondescription(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs !== false && !strlen($function->phpdocs->get_description())) {
-            $errors[] = array(
+            $errors[] = [
                 'line' => $function->phpdocs->get_line_number($file),
-                'object' => $function->name
-            );
+                'object' => $function->name,
+            ];
         }
     }
     return $errors;
@@ -420,7 +420,7 @@ function local_moodlecheck_functiondescription(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
 
     foreach ($file->get_functions() as $function) {
         if ($function->phpdocs !== false) {
@@ -469,9 +469,9 @@ function local_moodlecheck_functionarguments(local_moodlecheck_file $file) {
                 }
             }
             if (!$match) {
-                $errors[] = array(
+                $errors[] = [
                     'line' => $function->phpdocs->get_line_number($file, '@param'),
-                    'function' => $function->fullname);
+                    'function' => $function->fullname, ];
             }
         }
     }
@@ -521,14 +521,14 @@ function local_moodlecheck_normalise_function_type(string $typelist): string {
  * @return array of found errors
  */
 function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_variables() as $variable) {
         if ($variable->phpdocs !== false) {
             $documentedvars = $variable->phpdocs->get_params('var', 2);
             if (!count($documentedvars) || $documentedvars[0][0] == 'type') {
-                $errors[] = array(
+                $errors[] = [
                     'line' => $variable->phpdocs->get_line_number($file, '@var'),
-                    'variable' => $variable->fullname);
+                    'variable' => $variable->fullname, ];
             }
         }
     }
@@ -542,12 +542,12 @@ function local_moodlecheck_variableshasvar(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_definedoccorrect(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     foreach ($file->get_defines() as $object) {
         if ($object->phpdocs !== false) {
             if (!preg_match('/^\s*'.$object->name.'\s+-\s+(.*)/', $object->phpdocs->get_description(), $matches) ||
                     !strlen(trim($matches[1]))) {
-                $errors[] = array('line' => $object->phpdocs->get_line_number($file), 'object' => $object->fullname);
+                $errors[] = ['line' => $object->phpdocs->get_line_number($file), 'object' => $object->fullname];
             }
         }
     }
@@ -563,9 +563,9 @@ function local_moodlecheck_definedoccorrect(local_moodlecheck_file $file) {
 function local_moodlecheck_filehascopyright(local_moodlecheck_file $file) {
     $phpdocs = $file->find_file_phpdocs();
     if ($phpdocs && !count($phpdocs->get_tags('copyright', true))) {
-        return array(array('line' => $phpdocs->get_line_number($file, '@copyright')));
+        return [['line' => $phpdocs->get_line_number($file, '@copyright')]];
     }
-    return array();
+    return [];
 }
 
 /**
@@ -577,7 +577,7 @@ function local_moodlecheck_filehascopyright(local_moodlecheck_file $file) {
 function local_moodlecheck_filehaslicense(local_moodlecheck_file $file) {
     $phpdocs = $file->find_file_phpdocs();
     if ($phpdocs && !count($phpdocs->get_tags('license', true))) {
-        return array(array('line' => $phpdocs->get_line_number($file, '@license')));
+        return [['line' => $phpdocs->get_line_number($file, '@license')]];
     }
-    return array();
+    return [];
 }

--- a/rules/phpdocs_package.php
+++ b/rules/phpdocs_package.php
@@ -37,7 +37,7 @@ local_moodlecheck_registry::add_rule('categoryvalid')->set_callback('local_moodl
  * @return array of found errors
  */
 function local_moodlecheck_packagespecified(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     $phpdocs = $file->find_file_phpdocs();
     if ($phpdocs && count($phpdocs->get_tags('package', true))) {
         // Package is specified on file level, it is automatically inherited.
@@ -73,13 +73,13 @@ function local_moodlecheck_packagespecified(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_packagevalid(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
 
     $allowedpackages = local_moodlecheck_package_names($file);
     foreach ($file->get_all_phpdocs() as $phpdoc) {
         foreach ($phpdoc->get_tags('package') as $package) {
             if (!in_array($package, $allowedpackages)) {
-                $errors[] = array('line' => $phpdoc->get_line_number($file, '@package'), 'package' => $package);
+                $errors[] = ['line' => $phpdoc->get_line_number($file, '@package'), 'package' => $package];
             }
         }
     }
@@ -93,12 +93,12 @@ function local_moodlecheck_packagevalid(local_moodlecheck_file $file) {
  * @return array of found errors
  */
 function local_moodlecheck_categoryvalid(local_moodlecheck_file $file) {
-    $errors = array();
+    $errors = [];
     $allowedcategories = local_moodlecheck_get_categories($file);
     foreach ($file->get_all_phpdocs() as $phpdoc) {
         foreach ($phpdoc->get_tags('category') as $category) {
             if (!in_array($category, $allowedcategories)) {
-                $errors[] = array('line' => $phpdoc->get_line_number($file, '@category'), 'category' => $category);
+                $errors[] = ['line' => $phpdoc->get_line_number($file, '@category'), 'category' => $category];
             }
         }
     }
@@ -115,9 +115,9 @@ function local_moodlecheck_categoryvalid(local_moodlecheck_file $file) {
  * @return array
  */
 function local_moodlecheck_package_names(local_moodlecheck_file $file) {
-    static $allplugins = array();
-    static $allsubsystems = array();
-    static $corepackages  = array();
+    static $allplugins = [];
+    static $allsubsystems = [];
+    static $corepackages  = [];
     // Get and cache the list of plugins.
     if (empty($allplugins)) {
         $components = local_moodlecheck_path::get_components();
@@ -155,7 +155,7 @@ function local_moodlecheck_package_names(local_moodlecheck_file $file) {
     // Return valid plugin if the $file belongs to it.
     foreach ($allplugins as $pluginfullname => $dir) {
         if ($file->is_in_dir($dir)) {
-            return array($pluginfullname);
+            return [$pluginfullname];
         }
     }
 
@@ -172,7 +172,7 @@ function local_moodlecheck_package_names(local_moodlecheck_file $file) {
  * @return array
  */
 function &local_moodlecheck_get_plugins() {
-    static $allplugins = array();
+    static $allplugins = [];
     if (empty($allplugins)) {
         $plugintypes = get_plugin_types();
         foreach ($plugintypes as $plugintype => $pluginbasedir) {
@@ -197,7 +197,7 @@ function &local_moodlecheck_get_plugins() {
  */
 function &local_moodlecheck_get_categories($forceoffline = false) {
     global $CFG;
-    static $allcategories = array();
+    static $allcategories = [];
     if (empty($allcategories)) {
         $lastsavedtime = get_user_preferences('local_moodlecheck_categoriestime');
         $lastsavedvalue = get_user_preferences('local_moodlecheck_categoriesvalue');
@@ -205,7 +205,7 @@ function &local_moodlecheck_get_categories($forceoffline = false) {
             // Update only once per day.
             $allcategories = explode(',', $lastsavedvalue);
         } else {
-            $allcategories = array();
+            $allcategories = [];
             $filecontent = false;
             if (!$forceoffline) {
                 $filecontent = @file_get_contents("https://moodledev.io/docs/apis");

--- a/tests/coverage.php
+++ b/tests/coverage.php
@@ -31,12 +31,12 @@ defined('MOODLE_INTERNAL') || die();
 return new class extends phpunit_coverage_info {
     /** @var array The list of folders relative to the plugin root to include in coverage generation. */
     protected $includelistfolders = [
-        'rules'
+        'rules',
     ];
 
     /** @var array The list of files relative to the plugin root to include in coverage generation. */
     protected $includelistfiles = [
-        'file.php'
+        'file.php',
     ];
 
     /** @var array The list of folders relative to the plugin root to exclude from coverage generation. */

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -461,7 +461,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
      *
      * @return  array
      */
-    public function anonymous_class_provider(): array {
+    public static function anonymous_class_provider(): array {
         $rootpath  = 'local/moodlecheck/tests/fixtures/anonymous';
         return [
             'return new class {' => [
@@ -536,7 +536,7 @@ class moodlecheck_rules_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function empty_nophp_files_provider(): array {
+    public static function empty_nophp_files_provider(): array {
         return [
             'empty' => ['local/moodlecheck/tests/fixtures/empty.php'],
             'nophp' => ['local/moodlecheck/tests/fixtures/nophp.php'],


### PR DESCRIPTION
There are some new rules in CI, a couple of them are:
- Short array syntax must be used to define arrays (Generic.Arrays.DisallowLongArraySyntax.Found)
- There should be a comma after the last array item in a multi-line array. (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)

This pull request is to address these.  It doesn't quite remove all warnings, since there's a couple of warnings caused by another change to the CI rules.