### PR TITLE
Bump to Moodle 4.4 requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
             plugin-ci: ^3
 
           # Lowest php versions supported by each branch (with master always being tested twice).
-          - php: 8.0
+          - php: 8.1
             moodle-branch: master
             database: pgsql
-          - php: 8.0
+          - php: 8.1
             moodle-branch: master
             database: pgsql
           - php: 8.0


### PR DESCRIPTION
Changes:
  - php81 is now required for 4.4dev and up