### PR TITLE
Add support for readonly constructor properties

### DIFF
--- a/file.php
+++ b/file.php
@@ -423,8 +423,16 @@ class local_moodlecheck_file {
                         $argtokens = array_values($argtokens);
 
                         for ($j = 0; $j < count($argtokens); $j++) {
+                            if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
+                                // T_READONLY introduced in PHP 8.1.
+                                if ($argtokens[$j][0] === T_READONLY) {
+                                    continue;
+                                }
+                            }
                             switch ($argtokens[$j][0]) {
                                 // Skip any whitespace, or argument visibility.
+                                case T_COMMENT:
+                                case T_DOC_COMMENT:
                                 case T_WHITESPACE:
                                 case T_PUBLIC:
                                 case T_PROTECTED:

--- a/tests/fixtures/phpdoc_constructor_property_promotion_readonly.php
+++ b/tests/fixtures/phpdoc_constructor_property_promotion_readonly.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_moodlecheck;
+
+use cm_info;
+use stdClass;
+
+/**
+ * A fixture to verify phpdoc tags used in constructor property promotion.
+ *
+ * @package   local_moodlecheck
+ * @copyright 2023 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class constructor_property_promotion {
+    /**
+     * An example of a constructor using constructor property promotion.
+     *
+     * @param stdClass|cm_info $cm The course module data
+     * @param string $name The name
+     * @param int|float $size The size
+     * @param null|string $description The description
+     * @param ?string $content The content
+     */
+    public function __construct(
+        private stdClass|cm_info $cm,
+        /** @var string The name of the course module */
+        public readonly string $name,
+        /** @var float|int The size */
+        public readonly float|int $size,
+        /** @var null|string The description */
+        protected readonly ?string $description = null,
+        protected ?string $content = null
+    ) {
+    }
+}

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -220,6 +220,33 @@ final class moodlecheck_rules_test extends \advanced_testcase {
     }
 
     /**
+     * Verify that constructor property promotion supports readonly properties.
+     *
+     * @covers ::local_moodlecheck_functionarguments
+     * @requires PHP >= 8.1
+     */
+    public function test_phpdoc_constructor_property_promotion_readonly(): void {
+        global $PAGE;
+        $output = $PAGE->get_renderer('local_moodlecheck');
+        $path = new local_moodlecheck_path(
+            'local/moodlecheck/tests/fixtures/phpdoc_constructor_property_promotion_readonly.php',
+            null
+        );
+        $result = $output->display_path($path, 'xml');
+
+        // Convert results to XML Objext.
+        $xmlresult = new \DOMDocument();
+        $xmlresult->loadXML($result);
+
+        // Let's verify we have received a xml with file top element and 8 children.
+        $xpath = new \DOMXpath($xmlresult);
+        $found = $xpath->query("//file/error");
+
+        $this->assertCount(0, $found);
+        $this->assertStringNotContainsString('constructor_property_promotion::__construct has incomplete parameters list', $result);
+    }
+
+    /**
      * Verify that constructor property promotion is supported.
      *
      * @covers ::local_moodlecheck_functionarguments


### PR DESCRIPTION
```php
public function __construct(
    public readonly int $foo,
    protected readonly int $bar,
) {}
```

The `readonly` keywords were being detected as types.