### PR TITLE
Remove noemptysecondlines check

### DIFF
--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -37,9 +37,6 @@ $string['privacy:metadata'] = 'The Moodle PHPdoc check plugin does not store any
 
 $string['error_emptynophpfile'] = 'The file is empty or doesn\'t contain PHP code. Skipped.';
 
-$string['rule_noemptysecondline'] = 'Php open tag in the first line is not followed by empty line';
-$string['error_noemptysecondline'] = 'Empty line found after PHP open tag';
-
 $string['rule_filephpdocpresent'] = 'File-level phpdocs block is present';
 $string['error_filephpdocpresent'] = 'File-level phpdocs block is not found';
 

--- a/rules/phpdocs_basic.php
+++ b/rules/phpdocs_basic.php
@@ -24,8 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-local_moodlecheck_registry::add_rule('noemptysecondline')->set_callback('local_moodlecheck_noemptysecondline')
-    ->set_severity('warning');
 local_moodlecheck_registry::add_rule('filephpdocpresent')->set_callback('local_moodlecheck_filephpdocpresent');
 local_moodlecheck_registry::add_rule('classesdocumented')->set_callback('local_moodlecheck_classesdocumented');
 local_moodlecheck_registry::add_rule('functionsdocumented')->set_callback('local_moodlecheck_functionsdocumented');
@@ -48,20 +46,6 @@ local_moodlecheck_registry::add_rule('phpdocsinvalidpathtag')->set_callback('loc
 local_moodlecheck_registry::add_rule('phpdocsinvalidinlinetag')->set_callback('local_moodlecheck_phpdocsinvalidinlinetag');
 local_moodlecheck_registry::add_rule('phpdocsuncurlyinlinetag')->set_callback('local_moodlecheck_phpdocsuncurlyinlinetag');
 local_moodlecheck_registry::add_rule('phpdoccontentsinlinetag')->set_callback('local_moodlecheck_phpdoccontentsinlinetag');
-
-/**
- * Checks if the first line in the file has open tag and second line is not empty
- *
- * @param local_moodlecheck_file $file
- * @return array of found errors
- */
-function local_moodlecheck_noemptysecondline(local_moodlecheck_file $file) {
-    $tokens = &$file->get_tokens();
-    if ($tokens[0][0] == T_OPEN_TAG && !$file->is_whitespace_token(1) && $file->is_multiline_token(0) == 1) {
-        return [];
-    }
-    return [['line' => 2]];
-}
 
 /**
  * Checks if file-level phpdocs block is present

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -27,7 +27,7 @@ use local_moodlecheck_registry;
  * @copyright  2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class moodlecheck_rules_test extends \advanced_testcase {
+final class moodlecheck_rules_test extends \advanced_testcase {
     public function setUp(): void {
         global $CFG;
         parent::setUp();

--- a/tests/moodlecheck_rules_test.php
+++ b/tests/moodlecheck_rules_test.php
@@ -613,7 +613,6 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $result = $output->display_path($path, 'text');
 
         $this->assertStringContainsString('tests/fixtures/error_and_warning.php', $result);
-        $this->assertStringContainsString('2: Empty line found after PHP open tag (warning)', $result);
         $this->assertStringContainsString('11: Class someclass is not documented (error)', $result);
         $this->assertStringContainsString('12: Function someclass::somefunc is not documented (warning)', $result);
     }
@@ -632,7 +631,6 @@ class moodlecheck_rules_test extends \advanced_testcase {
         $result = $output->display_path($path, 'html');
 
         $this->assertStringContainsString('tests/fixtures/error_and_warning.php</span>', $result);
-        $this->assertStringContainsString('<b>2</b>: Empty line found after PHP open tag (warning)', $result);
         $this->assertStringContainsString('<b>11</b>: Class <b>someclass</b> is not documented (error)', $result);
         $this->assertStringContainsString('<b>12</b>: Function <b>someclass::somefunc</b> is not documented (warning)', $result);
     }

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -24,7 +24,7 @@ namespace local_moodlecheck;
  * @copyright  2023 Andrew Lyons <andrew@nicols.co.uk>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class phpdocs_basic_test extends \advanced_testcase {
+final class phpdocs_basic_test extends \advanced_testcase {
 
     public static function setUpBeforeClass(): void {
         global $CFG;


### PR DESCRIPTION
Remove noemptysecondlines check
Already covered by:
* moodle.Files.BoilerplateComment.NoPHP
* PSR12.Files.FileHeader.HeaderPosition
