### PR TITLE
Disable some phpcs (phpdoc) sniffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,6 @@ jobs:
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci phplint
 
-      - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcpd
-
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail
         if: ${{ !cancelled() }}
@@ -162,15 +157,6 @@ jobs:
       - name: Moodle Code Checker
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci codechecker --max-warnings 0
-
-      - name: Moodle PHPDoc Checker
-        if: ${{ false }}
-        run: |
-          if [ ${{ matrix.plugin-ci }} == "^3" ]; then
-              moodle-plugin-ci phpdoc
-          else
-              moodle-plugin-ci phpdoc --max-warnings 0
-          fi
 
       - name: Validating
         if: ${{ !cancelled() }}

--- a/file.php
+++ b/file.php
@@ -22,6 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+// phpcs:disable moodle.Commenting.VariableComment.Missing
+// phpcs:disable moodle.Commenting.MissingDocblock.Missing
+// phpcs:disable moodle.Commenting.VariableComment.TagNotAllowed
+
 defined('MOODLE_INTERNAL') || die;
 
 /**

--- a/lang/en/local_moodlecheck.php
+++ b/lang/en/local_moodlecheck.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+// phpcs:disable moodle.Files.LangFilesOrdering
+
 $string['pluginname'] = 'Moodle PHPdoc check';
 $string['path'] = 'Path(s)';
 $string['ignorepath'] = 'Subpaths to ignore';

--- a/locallib.php
+++ b/locallib.php
@@ -22,9 +22,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+// phpcs:disable moodle.Commenting.VariableComment.Missing
+// phpcs:disable moodle.Commenting.MissingDocblock.Missing
+
 defined('MOODLE_INTERNAL') || die;
 require_once($CFG->libdir . '/formslib.php');
-require_once($CFG->dirroot. '/local/moodlecheck/file.php');
+require_once($CFG->dirroot . '/local/moodlecheck/file.php');
 
 /**
  * Handles one rule

--- a/tests/phpdocs_basic_test.php
+++ b/tests/phpdocs_basic_test.php
@@ -46,6 +46,11 @@ final class phpdocs_basic_test extends \advanced_testcase {
         );
     }
 
+    /**
+     * Data provider for test_local_moodlecheck_normalise_function_type.
+     *
+     * @return array
+     */
     public static function local_moodlecheck_normalise_function_type_provider(): array {
         return [
             'Simple case' => [


### PR DESCRIPTION
As far as this tool is becoming replaced
by moodle-cs and has been already deprecated
there isn't much interest into fixing all
the missing documentation.

Hence, disabling some sniffs and applying the
minimum changes towards allowing CI to pass.

Also, removing the `phpcpd` command (deprecated) and the `phpdoc` command itself (being replaced by `phpcs` and we don't care - in fact it was disabled for this plugin).